### PR TITLE
Delete all identities from the agent

### DIFF
--- a/tests/playbooks/post.yaml
+++ b/tests/playbooks/post.yaml
@@ -1,0 +1,6 @@
+- hosts: all
+  tasks:
+    - name: Delete all identies from the agent
+      shell: "ssh-add -D"
+        environment:
+          SSH_AUTH_SOCK: "{{ site_windmill_config_bastion.ssh_auth_sock }}"


### PR DESCRIPTION
Once we are done running our job on bastion, remove keys from ssh-agent,
just to be safe.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>