### PR TITLE
Add gcc dependency so we can compile our tox environment

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,4 +1,5 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see http://docs.openstack.org/infra/bindep/ for additional information.
 
+gcc-c++
 openssh-askpass


### PR DESCRIPTION
Signed-off-by: Paul Belanger <pabelanger@redhat.com>