### PR TITLE
Sync windmill repo to bastion

### DIFF
--- a/playbooks/bastion.yaml
+++ b/playbooks/bastion.yaml
@@ -8,5 +8,8 @@
 
 - hosts: bastion
   tasks:
-    - name: hello
-      shell: echo world
+    - name: Synchronize windmill repo
+      synchronize:
+        dest: ~/src/git.openstack.org/windmill
+        src: ~/src/git.openstack.org/windmill
+      no_log: true


### PR DESCRIPTION
We always want to make sure we have the latest version of the git repo
on disk.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>