### PR TITLE
Fix typo with git.openstack.org/openstack/windmill path

### DIFF
--- a/playbooks/bastion.yaml
+++ b/playbooks/bastion.yaml
@@ -10,5 +10,5 @@
   tasks:
     - name: Synchronize windmill repo
       synchronize:
-        dest: ~/src/git.openstack.org/windmill
-        src: ~/src/git.openstack.org/windmill
+        dest: ~/src/git.openstack.org/openstack/windmill
+        src: ~/src/git.openstack.org/openstack/windmill


### PR DESCRIPTION
Signed-off-by: Paul Belanger <pabelanger@redhat.com>