### PR TITLE
Use ansible_user_dir on bastion for src folder

### DIFF
--- a/playbooks/bastion.yaml
+++ b/playbooks/bastion.yaml
@@ -10,5 +10,5 @@
   tasks:
     - name: Synchronize required-project to bastion
       synchronize:
-        dest: ~/src
+        dest: "{{ ansible_user_dir }}"
         src: ~/src


### PR DESCRIPTION
Otherwise we copy things into /home/ubuntu/src/src

Signed-off-by: Paul Belanger <pabelanger@redhat.com>