### PR TITLE
Symlink ansible-network/windmill-config directory

### DIFF
--- a/playbooks/bastion.yaml
+++ b/playbooks/bastion.yaml
@@ -15,6 +15,12 @@
         rsync_opts:
           - "--exclude=.tox"
 
+    - name: Symlink ansible-network/windmill-config directory
+      file:
+        src: ~/src/github.com/ansible-network/windmill-config
+        dest: ~/.config/windmill
+        state: link
+
     - name: Bootstrap tox environment
       args:
         chdir: ~/src/git.openstack.org/openstack/windmill


### PR DESCRIPTION
This is becaue ansible.cfg is setup to use ~/.local/windmill for the
inventory files.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>