### PR TITLE
Fix bug with zuul-connections

### DIFF
--- a/ansible/group_vars/zuul-connections.yaml
+++ b/ansible/group_vars/zuul-connections.yaml
@@ -287,3 +287,6 @@ zuul_connections_ssh:
       316661303165353062643166393735366161
 
     ssh_key_private_dest: /var/lib/zuul/.ssh/github_id_rsa
+    # NOTE(pabelanger): This should be the default in windmill, push upstream.
+    ssh_key_public_content: False
+    ssh_known_hosts_content: False


### PR DESCRIPTION
In some cases, we don't want to add known_hosts or public keys. For this
we should be able to leave our dict empty, but because of a bug in
windmill we need to force them to false.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>