### PR TITLE
exclude-unprotected-branches by default for pabelanger tenant

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -20,6 +20,7 @@
 
 - tenant:
     name: pabelanger
+    exclude-unprotected-branches: true
     source:
       github.com:
         config-projects:


### PR DESCRIPTION
Force the usage of branch protection with github.com connections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>