### PR TITLE
Add merger config to zuul-executors

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -45,14 +45,16 @@ log_config = /etc/zuul/fingergw-logging.conf
 user = {{ zuul_user_name }}
 {% endif -%}
 
-{% if inventory_hostname in groups['zuul-merger'] %}
+{% if inventory_hostname in groups['zuul-merger'] or inventory_hostname in groups['zuul-executor'] %}
 [merger]
+{% if inventory_hostname in groups['zuul-merger'] %}
 git_dir = {{ zuul_user_home }}/git
-git_user_email = windmill@example.org
-git_user_name = windmill
 log_config = /etc/zuul/merger-logging.conf
 pidfile = /var/run/zuul-merger/zuul-merger.pid
 zuul_url = {{ hostvars['zs01'].ansible_host }}
+{% endif %}
+git_user_email = windmill@example.org
+git_user_name = windmill
 {% endif -%}
 
 {% if inventory_hostname in groups['zuul-web'] %}


### PR DESCRIPTION
We actually need a few executor settings to properly setup the merger on
zuul-executors.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>