### PR TITLE
Add note about disabled group for windmill

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,5 +1,9 @@
 bastion ansible_connection=local
 
+# NOTE(pabelanger): Hosts added to this group will not have playbooks run
+# against them.
+[disabled]
+
 [gear]
 zs01 ansible_host=38.108.68.16
 


### PR DESCRIPTION
Sometimes you need to disable a host and stop ansible from running
against it. Now we have that ability in windmill.

Depends-On: https://review.openstack.org/631854
Signed-off-by: Paul Belanger <pabelanger@redhat.com>