### PR TITLE
Revert "Disable ze01"

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -3,7 +3,6 @@ bastion ansible_connection=local
 # NOTE(pabelanger): Hosts added to this group will not have playbooks run
 # against them.
 [disabled]
-ze01
 
 [gear]
 zs01 ansible_host=38.108.68.16


### PR DESCRIPTION
This reverts commit 32eb378c81a33a6c44070476bbabcb7e2f8e9260.

This worked as expected, bring ze01 back online.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>