### PR TITLE
Add openstack/windmill-ops as required-project

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -7,6 +7,7 @@
       - github.com/ansible-network/windmill-config
     required-projects:
       - name: git.openstack.org/openstack/windmill
+      - name: git.openstack.org/openstack/windmill-ops
     secrets:
       - site_windmill_config_bastion
     semaphore: windmill-config-deploy


### PR DESCRIPTION
We'll eventually want to use this repo from bastion, add it to
required-projects in case we want to also use it from our job.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>