### PR TITLE
Add openstack-dev/ci-sandbox as config-project

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -15,6 +15,10 @@
     name: openstack.org
     source:
       git.openstack.org:
+        config-projects:
+          - openstack-dev/ci-sandbox:
+              include: pipeline
+
         untrusted-projects:
           - openstack-infra/zuul-jobs
 


### PR DESCRIPTION
We'll be experimenting on loading pipelines directly from git.o.o for
3pci testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>