### PR TITLE
Don't manage zuul service state

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -19,7 +19,7 @@ zuul_file_zuul_executor_service_manage: true
 
 zuul_service_zuul_executor_enabled: true
 zuul_service_zuul_executor_manage: true
-zuul_service_zuul_executor_state: started
+zuul_service_zuul_executor_state: false
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/zuul-fingergw.yaml
+++ b/ansible/group_vars/zuul-fingergw.yaml
@@ -18,7 +18,7 @@ zuul_file_zuul_fingergw_service_manage: true
 
 zuul_service_zuul_fingergw_enabled: true
 zuul_service_zuul_fingergw_manage: true
-zuul_service_zuul_fingergw_state: started
+zuul_service_zuul_fingergw_state: false
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/zuul-merger.yaml
+++ b/ansible/group_vars/zuul-merger.yaml
@@ -17,7 +17,7 @@ zuul_file_zuul_merger_service_manage: true
 
 zuul_service_zuul_merger_enabled: true
 zuul_service_zuul_merger_manage: true
-zuul_service_zuul_merger_state: started
+zuul_service_zuul_merger_state: false
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/zuul-scheduler.yaml
+++ b/ansible/group_vars/zuul-scheduler.yaml
@@ -19,7 +19,7 @@ zuul_file_zuul_scheduler_service_manage: true
 
 zuul_service_zuul_scheduler_enabled: true
 zuul_service_zuul_scheduler_manage: true
-zuul_service_zuul_scheduler_state: started
+zuul_service_zuul_scheduler_state: false
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/zuul-web.yaml
+++ b/ansible/group_vars/zuul-web.yaml
@@ -17,7 +17,7 @@ zuul_file_zuul_web_service_manage: true
 
 zuul_service_zuul_web_enabled: true
 zuul_service_zuul_web_manage: true
-zuul_service_zuul_web_state: started
+zuul_service_zuul_web_state: false
 
 # openstack.logrotate
 logrotate_configs:


### PR DESCRIPTION
There are cases where we actually want to restart zuul manually, but we
cannot do that today because our post jobs in zuul will try to enable
the service again, if stopped.  Now we no longer manage that via
windmill, and are free to stop / start zuul services without breaking
the post job.

Depends-On: https://review.openstack.org/631942
Signed-off-by: Paul Belanger <pabelanger@redhat.com>