### PR TITLE
Don't manage nodepool service state

### DIFF
--- a/ansible/group_vars/nodepool-builder.yaml
+++ b/ansible/group_vars/nodepool-builder.yaml
@@ -25,7 +25,6 @@ nodepool_file_nodepool_yaml_src: "{{ windmill_config_git_dest }}/nodepool/nodepo
 
 nodepool_service_nodepool_builder_enabled: true
 nodepool_service_nodepool_builder_manage: true
-nodepool_service_nodepool_builder_state: started
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/nodepool-launcher.yaml
+++ b/ansible/group_vars/nodepool-launcher.yaml
@@ -21,7 +21,6 @@ nodepool_file_nodepool_yaml_src: "{{ windmill_config_git_dest }}/nodepool/{{ inv
 
 nodepool_service_nodepool_launcher_enabled: true
 nodepool_service_nodepool_launcher_manage: true
-nodepool_service_nodepool_launcher_state: started
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -26,11 +26,11 @@ nodepool_file_nodepool_yaml_src: "{{ windmill_config_git_dest }}/nodepool/nodepo
 
 nodepool_service_nodepool_builder_enabled: false
 nodepool_service_nodepool_builder_manage: false
-nodepool_service_nodepool_builder_state: stopped
+nodepool_service_nodepool_builder_state: false
 
 nodepool_service_nodepool_launcher_enabled: false
 nodepool_service_nodepool_launcher_manage: false
-nodepool_service_nodepool_launcher_state: stopped
+nodepool_service_nodepool_launcher_state: false
 
 nodepool_pip_version: 3.4.0
 nodepool_pip_virtualenv_python: python3


### PR DESCRIPTION
Like we did with zuul, we don't actually want to manage the service
state of nodepool. This allows for operators to potentially restart
services behind ansible-playbook runs.

Depends-On: https://review.openstack.org/632006
Signed-off-by: Paul Belanger <pabelanger@redhat.com>