### PR TITLE
Set executor.hostname in zuul.conf

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -33,6 +33,7 @@ state_dir = {{ zuul_user_home }}
 {% if inventory_hostname in groups['zuul-executor'] %}
 [executor]
 finger_port = 17979
+hostname = {{ hostvars[inventory_hostname].ansible_host }}
 log_config = /etc/zuul/executor-logging.conf
 private_key_file = {{ zuul_user_home }}/.ssh/nodepool_id_rsa
 workspace_root = {{ zuul_user_home }}/workspace


### PR DESCRIPTION
Because we don't have fqdn setup on all servers, tell the zuul-executors
which 'hostname' to use when talking with zuul-fingergw.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>