### PR TITLE
Start work on windmill-config-deploy2

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -13,3 +13,17 @@
       - site_windmill_config_bastion
     semaphore: windmill-config-deploy
     nodeset: fedora-latest-1vcpu
+
+- job:
+    name: windmill-config-deploy2
+    run: playbooks/bastion2.yaml
+    allowed-projects:
+      - github.com/ansible-network/windmill-config
+    required-projects:
+      - name: git.openstack.org/openstack/windmill
+      - name: git.openstack.org/openstack/windmill-ops
+    secrets:
+      - site_windmill_config_bastion
+    semaphore: windmill-config-deploy
+    nodeset:
+      nodes: []

--- a/.zuul.d/projects.yaml
+++ b/.zuul.d/projects.yaml
@@ -7,4 +7,4 @@
         - windmill-config-deploy
     post:
       jobs:
-        - windmill-config-deploy
+        - windmill-config-deploy2

--- a/playbooks/bastion2.yaml
+++ b/playbooks/bastion2.yaml
@@ -1,0 +1,20 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Add bastion server
+      add_host:
+        name: "{{ site_windmill_config_bastion.fqdn }}"
+        ansible_user: "{{ site_windmill_config_bastion.ssh_username }}"
+        group: bastion
+
+    - name: Add bastion server to known hosts
+      known_hosts:
+        name: "{{ site_windmill_config_bastion.fqdn }}"
+        key: "{{ site_windmill_config_bastion.ssh_known_hosts }}"
+
+- hosts: bastion
+  tasks:
+    - name: Bootstrap tox environment
+      args:
+        chdir: ~/src/git.openstack.org/openstack/windmill
+      shell: "{{ ansible_user_dir }}/.local/bin/tox -evenv --notest"


### PR DESCRIPTION
We'll be running ansible directly from zuul-executor, removing the need
for a node from nodepool.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>