### PR TITLE
Stop using tee with ansible-playbook

### DIFF
--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -35,7 +35,7 @@
         - name: Run ansible-playbook for site.yaml
           args:
             chdir: ~/src/git.openstack.org/openstack/windmill
-          shell: "{{ ansible_user_dir }}/.local/bin/tox -evenv -- ansible-playbook -v playbooks/site.yaml | tee {{ tmp_logs.path }}/job-output.txt"
+          shell: "{{ ansible_user_dir }}/.local/bin/tox -evenv -- ansible-playbook -v playbooks/site.yaml"
 
       always:
         - name: Generage UUID from ARA


### PR DESCRIPTION
This is no longer needed now that we run ansible-playbook from
zuul-executors.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>