### PR TITLE
Pin gear to 0.12.0

### DIFF
--- a/ansible/group_vars/gear.yaml
+++ b/ansible/group_vars/gear.yaml
@@ -15,8 +15,9 @@ gear_file_gear_service_config_src: gear/etc/systemd/system/gear.service.d/overri
 
 # TODO(pabelanger): Remove once https://review.openstack.org/558938 is merged
 gear_pip_extra_args: statsd
+gear_pip_version: 0.12.0
 gear_pip_virtualenv_python: python3
-gear_pip_virtualenv: /opt/venv/gear
+gear_pip_virtualenv: "/opt/venv/gear-{{ gear_pip_version }}"
 
 gear_file_ssl_ca_content: |
   -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Like we do with both nodepool / zuul, pin gear to allow for easier
upgrades / downgrades.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>