### PR TITLE
Remove ze01 / ze02 from ansible

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -27,8 +27,6 @@ zk02 ansible_host=38.108.68.106
 zk03 ansible_host=38.108.68.33
 
 [zuul-executor]
-ze01 ansible_host=38.108.68.133
-ze02 ansible_host=38.108.68.161
 ze03 ansible_host=38.108.68.49
 
 [zuul-fingergw]


### PR DESCRIPTION
We are preparing to rebuild these servers, ze03 can handle our traffic
for now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>