### PR TITLE
Manage zuul service states again

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -21,6 +21,7 @@ zuul_pip_name: zuul[zuul_executor]
 
 zuul_service_zuul_executor_enabled: true
 zuul_service_zuul_executor_manage: true
+zuul_service_zuul_executor_state: started
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/zuul-fingergw.yaml
+++ b/ansible/group_vars/zuul-fingergw.yaml
@@ -18,6 +18,7 @@ zuul_file_zuul_fingergw_service_manage: true
 
 zuul_service_zuul_fingergw_enabled: true
 zuul_service_zuul_fingergw_manage: true
+zuul_service_zuul_fingergw_state: started
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/zuul-merger.yaml
+++ b/ansible/group_vars/zuul-merger.yaml
@@ -17,6 +17,7 @@ zuul_file_zuul_merger_service_manage: true
 
 zuul_service_zuul_merger_enabled: true
 zuul_service_zuul_merger_manage: true
+zuul_service_zuul_merger_state: started
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/zuul-scheduler.yaml
+++ b/ansible/group_vars/zuul-scheduler.yaml
@@ -19,6 +19,7 @@ zuul_file_zuul_scheduler_service_manage: true
 
 zuul_service_zuul_scheduler_enabled: true
 zuul_service_zuul_scheduler_manage: true
+zuul_service_zuul_scheduler_state: started
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/zuul-web.yaml
+++ b/ansible/group_vars/zuul-web.yaml
@@ -17,6 +17,7 @@ zuul_file_zuul_web_service_manage: true
 
 zuul_service_zuul_web_enabled: true
 zuul_service_zuul_web_manage: true
+zuul_service_zuul_web_state: started
 
 # openstack.logrotate
 logrotate_configs:


### PR DESCRIPTION
So, we have a little issue here. If we bootstrap a replacement server
for the first time, we then need to manually start the server. The fix
here is to likey reboot the server the first time we bootstrap it,
however we don't have automation around that yet.  For now, simply
manage and if we need to stop / start services we can add the server
into the disabled group in the inventory.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>