### PR TITLE
Remove ze03 from production

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -28,7 +28,6 @@ zk03 ansible_host=38.108.68.33
 
 [zuul-executor]
 ze01 ansible_host=38.108.68.104
-ze03 ansible_host=38.108.68.49
 
 [zuul-fingergw]
 zf01 ansible_host=38.108.68.137


### PR DESCRIPTION
We've confirmed we can properly bootstrap an instances from first boot.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>