### PR TITLE
Add borg inventory group

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -4,6 +4,9 @@ bastion ansible_connection=local
 # against them.
 [disabled]
 
+[borg]
+borg01 ansible_host=38.108.68.89
+
 [gear]
 zs01 ansible_host=38.108.68.16
 


### PR DESCRIPTION
We'll eventually be using these hosts for our backups.  For now, add
them into ansible so we can bootstrap them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>