### PR TITLE
Add windmill-backup support to inventory

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -4,7 +4,10 @@ bastion ansible_connection=local
 # against them.
 [disabled]
 
-[borg]
+[borg-client:children]
+zuul-scheduler
+
+[borg-server]
 borg01 ansible_host=38.108.68.89
 
 [gear]


### PR DESCRIPTION
Rename borg group to borg-server and add zuul-scheduler into
borg-client. These groups are used by windmill-backup deployment.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>