### PR TITLE
Cap borgbackup / borgmatic versions

### DIFF
--- a/ansible/group_vars/borg.yaml
+++ b/ansible/group_vars/borg.yaml
@@ -10,9 +10,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 ---
+borgbackup_pip_version: 1.1.9
 borgbackup_pip_virtualenv_python: python3
-borgbackup_pip_virtualenv: /opt/venv/borgbackup
+borgbackup_pip_virtualenv: "/opt/venv/borgbackup-{{ borgbackup_pip_version }}"
 borgbackup_user_shell: /bin/bash
 
+borgmatic_pip_version: 1.2.15
 borgmatic_pip_virtualenv_python: python3
-borgmatic_pip_virtualenv: /opt/venv/borgmatic
+borgmatic_pip_virtualenv: "/opt/venv/borgmatic-{{ borgmatic_pip_version }}"


### PR DESCRIPTION
This allows up to safely upgrade / downgrade versions of each software
by creating version specific virtualenv.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>