### PR TITLE
Add zookeeper to borg-client group

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -9,6 +9,7 @@ borg-client
 borg-server
 
 [borg-client:children]
+zookeeper
 zuul-scheduler
 
 [borg-server]


### PR DESCRIPTION
Lets keep a backup of zookeeper, incase we somehow lose our cluster.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>