### PR TITLE
Add local_path for borgmatic configuration

### DIFF
--- a/borgmatic/zookeeper.yaml.j2
+++ b/borgmatic/zookeeper.yaml.j2
@@ -14,6 +14,7 @@ location:
         - borg_{{ inventory_hostname }}@{{ hostvars[host].ansible_host }}:sourcehostname.borg
 {% endfor %}
 {% endif %}
+    local_path: {{ borgbackup_pip_virtualenv }}/bin/borg
 
 retention:
     # Retention policy for how many backups to keep in each category.


### PR DESCRIPTION
Since we use virtualenvs for borgmatic, we need to provide the full path
to the borg binary.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>