### PR TITLE
Setup borgbackup_user_groups variable

### DIFF
--- a/ansible/group_vars/zookeeper.yaml
+++ b/ansible/group_vars/zookeeper.yaml
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 ---
+borgbackup_user_groups: zookeeper
 borgmatic_file_config_yaml_src: "{{ windmill_config_git_dest }}/borgmatic/zookeeper.yaml.j2"
 
 __borgmatic_encryption_passphrase: !vault |

--- a/ansible/group_vars/zuul-scheduler.yaml
+++ b/ansible/group_vars/zuul-scheduler.yaml
@@ -32,6 +32,7 @@ logrotate_configs:
       - daily
       - notifempty
 
+borgbackup_user_groups: zuul
 borgmatic_file_config_yaml_src: "{{ windmill_config_git_dest }}/borgmatic/zuul-scheduler.yaml.j2"
 
 __borgmatic_encryption_passphrase: !vault |


### PR DESCRIPTION
This is needed to allow borgbackup to read zookeeper / zuul files.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>