### PR TITLE
Remove /var/lib/zuul/keys from borgmatic

### DIFF
--- a/borgmatic/zuul-scheduler.yaml.j2
+++ b/borgmatic/zuul-scheduler.yaml.j2
@@ -5,7 +5,6 @@
 location:
     # List of source directories to backup. Globs are expanded.
     source_directories:
-        - /var/lib/zuul/keys
         - /var/lib/zuul/times
 
     # Paths to local or remote repositories.


### PR DESCRIPTION
There is a bug in zuul, where we only set 0700 on the
/var/lib/zuul/keys folder. This means borgmatic currently cannot read
the contents.  Until we fix this upstream, don't backup keys.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>