### PR TITLE
Fix linter jobs

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,5 +1,9 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see http://docs.openstack.org/infra/bindep/ for additional information.
 
+libffi-devel [platform:rpm]
+libffi-dev [platform:dpkg]
+libssl-dev [platform:dpkg]
 gcc-c++
 openssh-askpass
+openssl-devel [platform:rpm]


### PR DESCRIPTION
Install development headers to compile ansible properly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>