### PR TITLE
Setup roles path for windmill-ops deployment

### DIFF
--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -48,6 +48,7 @@
           args:
             chdir: ~/src/git.openstack.org/openstack/windmill-ops
           environment:
+            ANSIBLE_ROLES_PATH: "{{ ansible_user_dir }}/src/git.openstack.org/openstack/windmill-ops/playbooks/roles"
             PYTHONUNBUFFERED: 1
           shell: "{{ ansible_user_dir }}/.local/bin/tox -evenv -- ansible-playbook -v playbooks/bootstrap/site.yaml"
 


### PR DESCRIPTION
We really should consider using ~/.ansible/roles here, otherwise we have
3 locations now to look for roles.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>