### PR TITLE
Revert "Setup roles path for windmill-ops deployment"

### DIFF
--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -48,7 +48,6 @@
           args:
             chdir: ~/src/git.openstack.org/openstack/windmill-ops
           environment:
-            ANSIBLE_ROLES_PATH: "{{ ansible_user_dir }}/src/git.openstack.org/openstack/windmill-ops/playbooks/roles"
             PYTHONUNBUFFERED: 1
           shell: "{{ ansible_user_dir }}/.local/bin/tox -evenv -- ansible-playbook -v playbooks/bootstrap/site.yaml"
 


### PR DESCRIPTION
This reverts commit bc6ff131e7ae2fbdc348e4dc7071c43afd3f01de.