### PR TITLE
Create bastion group (again)

### DIFF
--- a/ansible/group_vars/bastion.yaml
+++ b/ansible/group_vars/bastion.yaml
@@ -1,0 +1,20 @@
+# Copyright 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+---
+ansible_pip_name:
+  - ansible
+  - ara
+  - netaddr
+ansible_pip_virtualenv_python: python3
+ansible_pip_virtualenv: /opt/venv/ansible

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,3 +1,4 @@
+[bastion]
 bastion ansible_connection=local
 
 # NOTE(pabelanger): Hosts added to this group will not have playbooks run


### PR DESCRIPTION
It actually is good for us to support more then 1 bastion, this will
allow us to rebuild servers as needed.  Also include ansible specific
variables for creating our virtualenv.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>