### PR TITLE
Delete ara database after each deploy

### DIFF
--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -98,3 +98,9 @@
           file:
             path: "{{ tmp_logs.path }}"
             state: absent
+
+        # TODO(pabelanger): Move ara into mysql database
+        - name: Delete ara ansible.sqlite database
+          file:
+            path: ~/.ara/ansible.sqlite
+            state: absent


### PR DESCRIPTION
Right now our ARA database is 1.6GB, and takes more then 10mins now to
generate reports. For now, we can just delete it after each run, but
ideally we more ARA into mysql to get better preformance.

We first need to stand up a database server.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>