### PR TITLE
Bump zuul to 3.6.1

### DIFF
--- a/ansible/group_vars/zuul.yaml
+++ b/ansible/group_vars/zuul.yaml
@@ -16,7 +16,7 @@ zuul_user_shell: /bin/bash
 zuul_file_main_yaml_src: "{{ windmill_config_git_dest }}/zuul/main.yaml"
 zuul_file_zuul_conf_src: "{{ windmill_config_git_dest }}/zuul/zuul.conf.j2"
 
-zuul_pip_version: 3.6.0
+zuul_pip_version: 3.6.1
 zuul_pip_virtualenv_python: python3
 zuul_pip_virtualenv: "/opt/venv/zuul-{{ zuul_pip_version }}"
 


### PR DESCRIPTION
This fixes a potential exploit using the raw task in a trusted job.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>