### PR TITLE
Add ansible_ssh_host_key_ed25519_public info for bastion

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -4,6 +4,7 @@ all:
       hosts:
         bastion:
           ansible_connection: local
+          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOOaqWfpmnMiCYaLUq0ugyQ6OUIvTpZKIqLTG03HXxU5
     borg:
       children:
         borg-client: {}


### PR DESCRIPTION
Once we merge a new upstream change to windmill-ops, we'll start
managing ~/.ssh/known_hosts on our bastion hosts.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>