### PR TITLE
Switch bastion to use ansible_host

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -3,7 +3,7 @@ all:
     bastion:
       hosts:
         bastion:
-          ansible_connection: local
+          ansible_host: 38.108.68.57
           ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOOaqWfpmnMiCYaLUq0ugyQ6OUIvTpZKIqLTG03HXxU5
     borg:
       children:


### PR DESCRIPTION
It seems there are issues with hostvars working with ansible_connection
local.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>