### PR TITLE
Add ed25519 host key for nb01

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -40,6 +40,7 @@ all:
       hosts:
         nb01:
           ansible_host: 38.108.68.29
+          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIKn1kJxF4u/yg7qXb9YS7XLRCj6tw1IrHc49zQmyLOU0
           ansible_user: windmill
         nb02:
           ansible_host: 38.108.68.95


### PR DESCRIPTION
This is to validate our known_hosts logic is working properly, then we
can add the rest of the hosts.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>