### PR TITLE
Reorganize ansible inventory

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,10 +1,72 @@
 all:
+  hosts:
+    bastion:
+      ansible_host: 38.108.68.57
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOOaqWfpmnMiCYaLUq0ugyQ6OUIvTpZKIqLTG03HXxU5
+    borg01:
+      ansible_host: 38.108.68.96
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIP4IzsYhfA6r5KkwV95Nzz5P2DKQU7xyHlXg1ANu6Y4X
+      ansible_user: windmill
+    borg02:
+      ansible_host: 38.108.68.45
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIASKTG74QOJ4gKOV8qLIfrarKT8+3wfUmhzy1o+kHFED
+      ansible_user: windmill
+    nb01:
+      ansible_host: 38.108.68.29
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIKn1kJxF4u/yg7qXb9YS7XLRCj6tw1IrHc49zQmyLOU0
+      ansible_user: windmill
+    nb02:
+      ansible_host: 38.108.68.95
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIANuuc1bEMbjKgcr+XH6hlobR6J2BvHg9+RS7U7NzN6j
+      ansible_user: windmill
+    nl01:
+      ansible_host: 38.108.68.109
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAINgd2l1FHxa7EO56k++u780J74O7DQ/RgKxgBa4b4fSl
+      ansible_user: windmill
+    nl02:
+      ansible_host: 38.108.68.98
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOxOFZoUg8xystPamPVkRrnqwVemG7bj+rVkLzp5D/0Y
+      ansible_user: windmill
+    ze01:
+      ansible_host: 38.108.68.104
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOSIhbE7coJYLz/FAuYA6AmhuTZhZaH7C8VkLgwORUMz
+      ansible_user: windmill
+    zf01:
+      ansible_host: 38.108.68.137
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAII8DkSFhxH/jRw/Wc5P9Ra7WwqPbnrqzsyXo1ng+2HJm
+      ansible_user: windmill
+    zk01:
+      ansible_host: 38.108.68.39
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIJV10E4FoCw+Bp6KqWdZiWIhafLVRa4oBE1M0Ti/w7cu
+      ansible_user: windmill
+    zk02:
+      ansible_host: 38.108.68.106
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAID1nJ/NSK/nTPzkIhi80aSfSpiAncb3MmXr7/IiP7aD6
+      ansible_user: windmill
+    zk03:
+      ansible_host: 38.108.68.33
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAINiEAxUZKtG7028y6Yj7C4MuUUwjWVLq3Gd2mnKmRqWQ
+      ansible_user: windmill
+    zm01:
+      ansible_host: 38.108.68.12
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIJxY9v/5wKgWURzXM3RRa4dW42ArQqKNkUzRnCvpxIr6
+      ansible_user: windmill
+    zm02:
+      ansible_host: 38.108.68.110
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAILCBMJHnncKc7EPpG4rKVWBaPXJ9ITWsqBtwx1hNexsc
+      ansible_user: windmill
+    zs01:
+      ansible_host: 38.108.68.16
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIO6X6m2J4Z7HlsKPNk6LtlGDGyaysPdP29klHYUUaBpJ
+      ansible_user: windmill
+    zw01:
+      ansible_host: 38.108.68.135
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIK1ZwJ74IRWcf1xzkgw9KCJcsOE/cU/Stat8+Y4yWCUO
+      ansible_user: windmill
   children:
     bastion:
       hosts:
         bastion:
-          ansible_host: 38.108.68.57
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOOaqWfpmnMiCYaLUq0ugyQ6OUIvTpZKIqLTG03HXxU5
     borg:
       children:
         borg-client: {}
@@ -19,22 +81,13 @@ all:
     borg-server:
       hosts:
         borg01:
-          ansible_host: 38.108.68.96
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIP4IzsYhfA6r5KkwV95Nzz5P2DKQU7xyHlXg1ANu6Y4X
-          ansible_user: windmill
         borg02:
-          ansible_host: 38.108.68.45
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIASKTG74QOJ4gKOV8qLIfrarKT8+3wfUmhzy1o+kHFED
-          ansible_user: windmill
     # NOTE(pabelanger): Hosts added to the disabled group will not have
     # playbooks run against them.
     disabled: {}
     gear:
       hosts:
         zs01:
-          ansible_host: 38.108.68.16
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIO6X6m2J4Z7HlsKPNk6LtlGDGyaysPdP29klHYUUaBpJ
-          ansible_user: windmill
     nodepool:
       children:
         nodepool-builder: {}
@@ -42,38 +95,17 @@ all:
     nodepool-builder:
       hosts:
         nb01:
-          ansible_host: 38.108.68.29
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIKn1kJxF4u/yg7qXb9YS7XLRCj6tw1IrHc49zQmyLOU0
-          ansible_user: windmill
         nb02:
-          ansible_host: 38.108.68.95
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIANuuc1bEMbjKgcr+XH6hlobR6J2BvHg9+RS7U7NzN6j
-          ansible_user: windmill
     nodepool-launcher:
       hosts:
         nl01:
-          ansible_host: 38.108.68.109
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAINgd2l1FHxa7EO56k++u780J74O7DQ/RgKxgBa4b4fSl
-          ansible_user: windmill
         nl02:
-          ansible_host: 38.108.68.98
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOxOFZoUg8xystPamPVkRrnqwVemG7bj+rVkLzp5D/0Y
-          ansible_user: windmill
     statsd: {}
     zookeeper:
       hosts:
         zk01:
-          ansible_host: 38.108.68.39
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIJV10E4FoCw+Bp6KqWdZiWIhafLVRa4oBE1M0Ti/w7cu
-          ansible_user: windmill
         zk02:
-          ansible_host: 38.108.68.106
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAID1nJ/NSK/nTPzkIhi80aSfSpiAncb3MmXr7/IiP7aD6
-          ansible_user: windmill
         zk03:
-          ansible_host: 38.108.68.33
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAINiEAxUZKtG7028y6Yj7C4MuUUwjWVLq3Gd2mnKmRqWQ
-          ansible_user: windmill
     zuul:
       children:
         zuul-executor: {}
@@ -89,34 +121,16 @@ all:
     zuul-executor:
       hosts:
         ze01:
-          ansible_host: 38.108.68.104
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOSIhbE7coJYLz/FAuYA6AmhuTZhZaH7C8VkLgwORUMz
-          ansible_user: windmill
     zuul-fingergw:
       hosts:
         zf01:
-          ansible_host: 38.108.68.137
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAII8DkSFhxH/jRw/Wc5P9Ra7WwqPbnrqzsyXo1ng+2HJm
-          ansible_user: windmill
     zuul-merger:
       hosts:
         zm01:
-          ansible_host: 38.108.68.12
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIJxY9v/5wKgWURzXM3RRa4dW42ArQqKNkUzRnCvpxIr6
-          ansible_user: windmill
         zm02:
-          ansible_host: 38.108.68.110
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAILCBMJHnncKc7EPpG4rKVWBaPXJ9ITWsqBtwx1hNexsc
-          ansible_user: windmill
     zuul-scheduler:
       hosts:
         zs01:
-          ansible_host: 38.108.68.16
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIO6X6m2J4Z7HlsKPNk6LtlGDGyaysPdP29klHYUUaBpJ
-          ansible_user: windmill
     zuul-web:
       hosts:
         zw01:
-          ansible_host: 38.108.68.135
-          ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIK1ZwJ74IRWcf1xzkgw9KCJcsOE/cU/Stat8+Y4yWCUO
-          ansible_user: windmill


### PR DESCRIPTION
Create top-level hosts, to centralize all the hosts. Then we can just
add each host to given groups.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>