### PR TITLE
Bring bastion01.eng.ansible.com online

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,5 +1,11 @@
 all:
   hosts:
+    bastion01.eng.ansible.com:
+      ansible_host: 38.108.68.54
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIJmAP+1SoXQU/fpjisHf7xQ6sVqSYwSYUPe51YCVfsrY
+      ansible_user: windmill
+    # TODO(pabelanger): We'll be removing the servers below as we are in the
+    # process of rebuilding everything.
     bastion:
       ansible_host: 38.108.68.57
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOOaqWfpmnMiCYaLUq0ugyQ6OUIvTpZKIqLTG03HXxU5
@@ -67,6 +73,7 @@ all:
     bastion:
       hosts:
         bastion:
+        bastion01.eng.ansible.com:
     borg:
       children:
         borg-client: {}


### PR DESCRIPTION
We have a new project in vexxhost that we'll be running our zuul control
plane in. Start with bastion01.eng.ansible.com, then we can process to
replace all the other servers.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>