### PR TITLE
Add SF.io Zuul public SSH key to bastion group

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -19,7 +19,7 @@ virtualenv_install_method: package
 # TODO(pabelanger): Create windmill-config project on git.o.o.
 windmill_config_git_dest: ~/.config/windmill
 
-windmill_users:
+_windmill_users:
   windmill:
     comment: Bastion
     key: |
@@ -32,6 +32,8 @@ windmill_users:
     key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCuP0CZE8AYnbm8gxecCxKeRw0wHRyryd+FKmNNsdr0d3UvfCbqNzLigrqEBZsKpofi3M4qCWNpKRyfhnjPynLTQjP1vnX9AbL9UGoiHxScfvh3skntTYMs9ezJRd0rMJJZO76FPo8bJLDlwxAQl8m/nuj3HfYiO5hYE7P+a3rhsJh4nEfBb7xh+Q5yM0PWObkkBl6IRiBYjlcsXNZHgTA5kNuihUk5bHqAw54sHh05DhpgOITpTw4LFbh4Ew2NKq49dEb2xbTuAyAr2DHNOGgIwKEZpwtKZEIGEuiLbb4DQRsfivrvyOjnK2NFjQzGyNOHfsOldWHRQwUKUs8nrxKdXvqcrfMnSVaibeYK2TRL+6jd9kc5SIhWI3XLm7HbX7uXMD7/JQrkL25Rcs6nndDCH72DJLz+ynA/T5umMbNBQ9tybL5z73IOpfShRGjQYego22CxDOy7e/5OEMHNoksbFb1S02viM9O2puS7LDqqfT9JIbbPqCrbRi/zOXo0f4EXo6xKUAmd8qlV+6f/p57/qFihzQDaRFVlFEH3k7qwsw7PYGUTwkPaThe6xyZN6D5jqxCZU3aSYu+FGb0oYo+M5IxOm0Cb4NNsvvkRPxWtwSayfFGu6+m/+/RyA3GBcAMev7AuyKN+K2vGMsLagHOx4i+5ZAcUwGzLeXAENNum3w==
     gid: 2001
     uid: 2001
+
+windmill_users: "{{ _windmill_users }}"
 
 windmill_root_users:
   - pabelanger

--- a/ansible/group_vars/bastion.yaml
+++ b/ansible/group_vars/bastion.yaml
@@ -18,3 +18,13 @@ ansible_pip_name:
   - netaddr
 ansible_pip_virtualenv_python: python3
 ansible_pip_virtualenv: /opt/venv/ansible-2.7.8
+
+# NOTE(pabelanger): We only want the zuul to have access to bastion servers,
+# so we need to dynamically inject the SSH public key into windmill_users.
+__windmill_users:
+  windmill:
+    key: |
+      {{ _windmill_users['windmill'].key }}
+      ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCXfZWYKCxQznnrELlXkeHmArdzUJt4CUeKbLNI1dDx1ZDF7xsu+QmSFeXNyLuL8QzZSXw+lgN+DeMiXKuFBvX/xjUXxGWNHF0VKLOdQzcHgkFymX40+2nxxlzOGMYDpihomg6yrSIrkpV63lTB4HVT3pURf5mA8kzj6KD5r+wsX1DFWLrgfPjwMv2mDnzd9jcHP/AvP7sTnaqW6u4TDFEuZSpkbVzLxvhZh3k3zXn3zoPIeIvrXn8ybakobYv+e292Oe29Nt4SYl50AgafrijKLzV+fqiJ8g4rlEYXXfqqWHx2drcIHMI/6RABT6JMuoQuJtt+oMtFKF/jggZ8h/yZ zuul@ansible-network.softwarefactory-project.io
+
+windmill_users: "{{ _windmill_users|combine(__windmill_users, recursive=true) }}"


### PR DESCRIPTION
We only want to allow SSH access to our bastion services, for security
reasons.  This will still allow SF.io zuul to connect to bastion group
in the post / periodic pipelines.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>