### PR TITLE
Switch to bastion.eng.ansible.com to deploy ansible

### DIFF
--- a/.zuul.d/secrets.yaml
+++ b/.zuul.d/secrets.yaml
@@ -5,8 +5,7 @@
 - secret:
     name: site_windmill_config_bastion
     data:
-      fqdn: bastion.poctron.xyz
+      fqdn: 38.108.68.54
       ssh_known_hosts: |
-        bastion.poctron.xyz ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOOaqWfpmnMiCYaLUq0ugyQ6OUIvTpZKIqLTG03HXxU5
-      # TODO(pabelanger): Change this to zuul user.
-      ssh_username: ubuntu
+        bastion.eng.ansible.com,38.108.68.54 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJmAP+1SoXQU/fpjisHf7xQ6sVqSYwSYUPe51YCVfsrY
+      ssh_username: windmill


### PR DESCRIPTION
Another step towards moving our control plane into the correct vexxhost
tenant.  Once confirmed working, we can delete bastion01.poctron.xyz.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>