### PR TITLE
Set ansible_python_interpreter for add_host

### DIFF
--- a/tests/playbooks/bastion.yaml
+++ b/tests/playbooks/bastion.yaml
@@ -6,6 +6,7 @@
         name: "{{ site_windmill_config_bastion.fqdn }}"
         ansible_user: "{{ site_windmill_config_bastion.ssh_username }}"
         group: bastion
+        ansible_python_interpreter: python3
 
     - name: Add bastion server to known hosts
       known_hosts:


### PR DESCRIPTION
We only have python3 on bastion.eng.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>