### PR TITLE
Revert "Set ansible_python_interpreter for add_host"

### DIFF
--- a/tests/playbooks/bastion.yaml
+++ b/tests/playbooks/bastion.yaml
@@ -6,7 +6,6 @@
         name: "{{ site_windmill_config_bastion.fqdn }}"
         ansible_user: "{{ site_windmill_config_bastion.ssh_username }}"
         group: bastion
-        ansible_python_interpreter: python3
 
     - name: Add bastion server to known hosts
       known_hosts:


### PR DESCRIPTION
Sadly, zuul doesn't support this.

This reverts commit 203c6c7eeb867123dbbf625df4b8fce70e271aa5.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>