### PR TITLE
Revert "Remove PYTHONUNBUFFERED environment variables"

### DIFF
--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -38,6 +38,8 @@
       args:
         chdir: "{{ item }}"
         executable: /bin/bash
+      environment:
+        PYTHONUNBUFFERED: 1
       shell: source /opt/venv/ansible/bin/activate; ./tools/install_roles.sh --force
       with_items:
         - ~/src/git.openstack.org/openstack/windmill-ops
@@ -48,11 +50,15 @@
         - name: Deploy windmill-ops with ansible-playbook
           args:
             chdir: ~/src/git.openstack.org/openstack/windmill-ops
+          environment:
+            PYTHONUNBUFFERED: 1
           shell: /opt/venv/ansible/bin/ansible-playbook -v playbooks/bootstrap/site.yaml
 
         - name: Deploy windmill with ansible-playbook
           args:
             chdir: "{{ item }}"
+          environment:
+            PYTHONUNBUFFERED: 1
           shell: /opt/venv/ansible/bin/ansible-playbook -v playbooks/site.yaml
           with_items:
             - ~/src/git.openstack.org/openstack/windmill
@@ -62,24 +68,32 @@
         - name: Generage UUID from ARA
           args:
             chdir: ~/src/git.openstack.org/openstack/windmill
+          environment:
+            PYTHONUNBUFFERED: 1
           register: windmill_ops_uuid
           shell: "/opt/venv/ansible/bin/ara playbook list | grep windmill-ops/playbooks/bootstrap/site.yaml | tail -1 | cut -d' ' -f2"
 
         - name: Generage UUID from ARA
           args:
             chdir: ~/src/git.openstack.org/openstack/windmill
+          environment:
+            PYTHONUNBUFFERED: 1
           register: windmill_uuid
           shell: "/opt/venv/ansible/bin/ara playbook list | grep windmill/playbooks/site.yaml | tail -1 | cut -d' ' -f2"
 
         - name: Generage UUID from ARA
           args:
             chdir: ~/src/git.openstack.org/openstack/windmill
+          environment:
+            PYTHONUNBUFFERED: 1
           register: windmill_backup_uuid
           shell: "/opt/venv/ansible/bin/ara playbook list | grep windmill-backup/playbooks/site.yaml | tail -1 | cut -d' ' -f2"
 
         - name: Generate static HTML for ARA results
           args:
             chdir: ~/src/git.openstack.org/openstack/windmill
+          environment:
+            PYTHONUNBUFFERED: 1
           shell: "/opt/venv/ansible/bin/ara generate html {{ tmp_logs.path }}/ara-report --playbook {{ windmill_ops_uuid.stdout }} {{ windmill_uuid.stdout }} {{ windmill_backup_uuid.stdout }}"
 
         - name: Ensure zuul-output directory exists


### PR DESCRIPTION
Lets give this try again, now that zuul_console seems to be working on
our new bastion host.

This reverts commit fb91dbf788eca2cdd2eb3540fc7eefa478f723b2.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>