### PR TITLE
Remove bastion01.poctron.xyz from inventory

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -6,9 +6,6 @@ all:
       ansible_user: windmill
     # TODO(pabelanger): We'll be removing the servers below as we are in the
     # process of rebuilding everything.
-    bastion01:
-      ansible_host: 38.108.68.57
-      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIOOaqWfpmnMiCYaLUq0ugyQ6OUIvTpZKIqLTG03HXxU5
     borg01:
       ansible_host: 38.108.68.96
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIP4IzsYhfA6r5KkwV95Nzz5P2DKQU7xyHlXg1ANu6Y4X
@@ -72,7 +69,6 @@ all:
   children:
     bastion:
       hosts:
-        bastion01:
         bastion01.eng.ansible.com:
     borg:
       children:


### PR DESCRIPTION
We've successfully migrated to bastion01.eng.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>