### PR TITLE
Don't log rsync of logs back to executor

### DIFF
--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -95,6 +95,7 @@
             dest: "{{ zuul.executor.log_root }}/bastion"
             mode: pull
             src: "{{ tmp_logs.path }}/"
+          no_log: true
 
         - name: Delete tmp directory for logs
           file:


### PR DESCRIPTION
Signed-off-by: Paul Belanger <pabelanger@redhat.com>