### PR TITLE
Move statsd configuration intree

### DIFF
--- a/ansible/group_vars/statsd.yaml
+++ b/ansible/group_vars/statsd.yaml
@@ -11,7 +11,7 @@
 # under the License.
 ---
 # windmill.statsd
-statsd_file_config_js_src: statsd/etc/statsd/config.js.j2
+statsd_file_config_js_src: "{{ windmill_config_git_dest }}/statsd/etc/statsd/config.js.j2"
 
 # openstack.logrotate
 logrotate_configs:

--- a/statsd/etc/statsd/config.js.j2
+++ b/statsd/etc/statsd/config.js.j2
@@ -1,0 +1,8 @@
+{
+{% if ansible_host | ipv6 %}
+  address_ipv6: true,
+{% endif %}
+  backends: [ "./backends/console" ],
+  host: "{{ ansible_host }}",
+  port: 8125
+}


### PR DESCRIPTION
We want to be able to properly configure statsd, move it into our
configuration tree.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>