### PR TITLE
Revert "Don't manage nodepool service state"

### DIFF
--- a/ansible/group_vars/nodepool-builder.yaml
+++ b/ansible/group_vars/nodepool-builder.yaml
@@ -25,6 +25,7 @@ nodepool_file_nodepool_yaml_src: "{{ windmill_config_git_dest }}/nodepool/nodepo
 
 nodepool_service_nodepool_builder_enabled: true
 nodepool_service_nodepool_builder_manage: true
+nodepool_service_nodepool_builder_state: started
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/nodepool-launcher.yaml
+++ b/ansible/group_vars/nodepool-launcher.yaml
@@ -21,6 +21,7 @@ nodepool_file_nodepool_yaml_src: "{{ windmill_config_git_dest }}/nodepool/{{ inv
 
 nodepool_service_nodepool_launcher_enabled: true
 nodepool_service_nodepool_launcher_manage: true
+nodepool_service_nodepool_launcher_state: started
 
 # openstack.logrotate
 logrotate_configs:

--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -26,11 +26,11 @@ nodepool_file_nodepool_yaml_src: "{{ windmill_config_git_dest }}/nodepool/nodepo
 
 nodepool_service_nodepool_builder_enabled: false
 nodepool_service_nodepool_builder_manage: false
-nodepool_service_nodepool_builder_state: false
+nodepool_service_nodepool_builder_state: stopped
 
 nodepool_service_nodepool_launcher_enabled: false
 nodepool_service_nodepool_launcher_manage: false
-nodepool_service_nodepool_launcher_state: false
+nodepool_service_nodepool_launcher_state: stopped
 
 nodepool_pip_version: 3.5.0
 nodepool_pip_virtualenv_python: python3


### PR DESCRIPTION
We can place a server in the disabled group if we need to do things with
the service.

This reverts commit d9d10a6e443df36f51880b4ed63e45ea2aaf08e8.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>