### PR TITLE
Remove servers from borg groups

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -53,14 +53,9 @@ all:
     # NOTE(pabelanger): Remember to create borgmatic configuration and
     # encryption_passphrase each time we add a new host to borg-client
     # group.
-    borg-client:
-      children:
-        bastion: {}
-        zookeeper: {}
+    borg-client: {}
 
-    borg-server:
-      hosts:
-        borg01.eng.ansible.com:
+    borg-server: {}
 
     # NOTE(pabelanger): Hosts added to the disabled group will not have
     # playbooks run against them.


### PR DESCRIPTION
We are going to rebuild everything under the zuul.ansible.com sub
domain, to make managing DNS easier.  As such, we need to prepare to
delete all these hosts and create bastion01.zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>