### PR TITLE
Add bastion01.sjc1.vexxhost.zuul.ci.ansible.com

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,5 +1,11 @@
 all:
   hosts:
+    bastion01.sjc1.vexxhost.zuul.ci.ansible.com:
+      ansible_host: 38.108.68.66
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAINuLhAMDJDwufpv7kQDVZke8Eivs6vvkbm4ucvGRGBrn
+      ansible_user: windmill
+
+    # NOTE(pabelanger): The following servers are to be deleted.
     bastion01.eng.ansible.com:
       ansible_host: 38.108.68.54
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIJmAP+1SoXQU/fpjisHf7xQ6sVqSYwSYUPe51YCVfsrY


### PR DESCRIPTION
We have a new sub domain to use: zuul.ci.ansible.com! We'll also be
scoping our servers by region / cloud, to help users understand where
the server lives.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>