### PR TITLE
Fix bastion01.sjc1.vexxhost.zuul.ci.ansible.com group

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -50,6 +50,7 @@ all:
     bastion:
       hosts:
         bastion01.eng.ansible.com:
+        bastion01.sjc1.vexxhost.zuul.ci.ansible.com:
 
     borg:
       children:


### PR DESCRIPTION
We forgot to add bastion01.sjc1.vexxhost.zuul.ci.ansible.com to the
correct group.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>