### PR TITLE
Bring bastion01.sjc1.vexxhost.zuul-ci.ansible.com online

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,11 +1,16 @@
 all:
   hosts:
+    bastion01.sjc1.vexxhost.zuul-ci.ansible.com:
+      ansible_host: 38.108.68.114
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIPVbbkDWEwZkas6hldXONrqO40vO9PdZnuxf8D8oNnmg
+      ansible_user: windmill
+
+    # NOTE(pabelanger): The following servers are to be deleted.
     bastion01.sjc1.vexxhost.zuul.ci.ansible.com:
       ansible_host: 38.108.68.66
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAINuLhAMDJDwufpv7kQDVZke8Eivs6vvkbm4ucvGRGBrn
       ansible_user: windmill
 
-    # NOTE(pabelanger): The following servers are to be deleted.
     bastion01.eng.ansible.com:
       ansible_host: 38.108.68.54
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIJmAP+1SoXQU/fpjisHf7xQ6sVqSYwSYUPe51YCVfsrY
@@ -15,6 +20,7 @@ all:
     bastion:
       hosts:
         bastion01.eng.ansible.com:
+        bastion01.sjc1.vexxhost.zuul-ci.ansible.com:
         bastion01.sjc1.vexxhost.zuul.ci.ansible.com:
 
     borg:


### PR DESCRIPTION
So, funny story, zuul-ci.ansible.com is now the subdomain we are going
to be using. Everybody involved in getting DNS on the ansible.com domain
has agreed to this.

Start the process of rotating out other 2 bastion hosts.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>