### PR TITLE
Remove bastion01.eng.ansible.com from inventory

### DIFF
--- a/ansible/hosts
+++ b/ansible/hosts
@@ -5,16 +5,9 @@ all:
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIPVbbkDWEwZkas6hldXONrqO40vO9PdZnuxf8D8oNnmg
       ansible_user: windmill
 
-    # NOTE(pabelanger): The following servers are to be deleted.
-    bastion01.eng.ansible.com:
-      ansible_host: 38.108.68.54
-      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIJmAP+1SoXQU/fpjisHf7xQ6sVqSYwSYUPe51YCVfsrY
-      ansible_user: windmill
-
   children:
     bastion:
       hosts:
-        bastion01.eng.ansible.com:
         bastion01.sjc1.vexxhost.zuul-ci.ansible.com:
 
     borg:


### PR DESCRIPTION
We've fully migrated to our new bastion host.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>