### PR TITLE
Switch to promote pipeline for windmill-config-deploy

### DIFF
--- a/.zuul.d/projects.yaml
+++ b/.zuul.d/projects.yaml
@@ -5,6 +5,6 @@
     periodic-1hr:
       jobs:
         - windmill-config-deploy
-    post:
+    promote:
       jobs:
         - windmill-config-deploy


### PR DESCRIPTION
This should let zuul now comment on the original PR once the job has
finished. Making it a little easier to audit.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>