### PR TITLE
Bring zs01.sjc1.vexxhost.zuul-ci.ansible.com online

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -65,6 +65,14 @@ all:
         public_ipv4: 38.108.68.67
         public_ipv6: ''
 
+    zs01.sjc1.vexxhost.zuul-ci.ansible.com:
+      ansible_host: 38.108.68.149
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIAI6H3XPa3/mKX1ZM7B3SHn/bGwcbYPmcMFNAk5MxbaL
+      ansible_user: windmill
+      node_attributes:
+        public_ipv4: 38.108.68.149
+        public_ipv6: ''
+
   children:
     bastion:
       hosts:
@@ -90,7 +98,9 @@ all:
     # playbooks run against them.
     disabled: {}
 
-    gear: {}
+    gear:
+      hosts:
+        zs01.sjc1.vexxhost.zuul-ci.ansible.com:
 
     nodepool:
       children:


### PR DESCRIPTION
And add to both gear and zuul-scheduler groups.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>