### PR TITLE
Fix zuul.conf template parsing errors

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -114,6 +114,9 @@ all:
     # playbooks run against them.
     disabled: {}
 
+    # NOTE(pabelanger): We currently only support a single gear host in this
+    # group.  This means, the first host listed will only be used by our
+    # configuration.
     gear:
       hosts:
         zs01.sjc1.vexxhost.zuul-ci.ansible.com:
@@ -130,6 +133,9 @@ all:
 
     nodepool-launcher: {}
 
+    # NOTE(pabelanger): We currently only support a single statsd host in this
+    # group.  This means, the first host listed will only be used by our
+    # configuration.
     statsd:
       hosts:
         statsd01.sjc1.vexxhost.zuul-ci.ansible.com:

--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -9,14 +9,14 @@ hosts = {{ groups['zookeeper'] | map('extract', hostvars, ['ansible_host']) | jo
 
 [gearman]
 port = 4730
-server = {{ hostvars['zs01'].ansible_host }}
+server = {{ hostvars[groups['gear'][0]].ansible_host }}
 ssl_ca = {{ zuul_file_gearman_ssl_ca_dest }}
 ssl_cert = {{ zuul_file_gearman_ssl_cert_dest }}
 ssl_key = {{ zuul_file_gearman_ssl_key_dest }}
 
 {% if groups['statsd'] | list and ansible_host | ipv4 %}
 [statsd]
-server = {{ hostvars['statsd01'].ansible_host }}
+server = {{ hostvars[groups['statsd'][0]].ansible_host }}
 {% endif -%}
 
 {% if inventory_hostname in groups['zuul-scheduler'] %}
@@ -52,7 +52,6 @@ user = {{ zuul_user_name }}
 git_dir = {{ zuul_user_home }}/git
 log_config = /etc/zuul/merger-logging.conf
 pidfile = /var/run/zuul-merger/zuul-merger.pid
-zuul_url = {{ hostvars['zs01'].ansible_host }}
 {% endif %}
 git_user_email = windmill@example.org
 git_user_name = windmill


### PR DESCRIPTION
We can remove an unused setting, and add a note about our gear / statsd
groups only support a single host.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>