### PR TITLE
Expose 19885/tcp on bastion group

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -37,3 +37,9 @@ windmill_users: "{{ _windmill_users }}"
 windmill_root_users:
   - pabelanger
   - windmill
+
+_iptables_public_tcp_ports_base:
+  - 22
+_iptables_public_tcp_ports_extra: []
+
+iptables_public_tcp_ports: "{{ _iptables_public_tcp_ports_base + _iptables_public_tcp_ports_extra }}"

--- a/ansible/group_vars/bastion.yaml
+++ b/ansible/group_vars/bastion.yaml
@@ -39,3 +39,7 @@ __windmill_users:
       ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCXfZWYKCxQznnrELlXkeHmArdzUJt4CUeKbLNI1dDx1ZDF7xsu+QmSFeXNyLuL8QzZSXw+lgN+DeMiXKuFBvX/xjUXxGWNHF0VKLOdQzcHgkFymX40+2nxxlzOGMYDpihomg6yrSIrkpV63lTB4HVT3pURf5mA8kzj6KD5r+wsX1DFWLrgfPjwMv2mDnzd9jcHP/AvP7sTnaqW6u4TDFEuZSpkbVzLxvhZh3k3zXn3zoPIeIvrXn8ybakobYv+e292Oe29Nt4SYl50AgafrijKLzV+fqiJ8g4rlEYXXfqqWHx2drcIHMI/6RABT6JMuoQuJtt+oMtFKF/jggZ8h/yZ zuul@ansible-network.softwarefactory-project.io
 
 windmill_users: "{{ _windmill_users|combine(__windmill_users, recursive=true) }}"
+
+# NOTE(pabelanger): This is so we can stream console logs with zuul_console.
+_iptables_public_tcp_ports_extra:
+  - 19885


### PR DESCRIPTION
IF we want to allow for zuul to stream ansible (console logs) we need to
allow this port on our firewall.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>