### PR TITLE
Only allow sf.io access to 19885/tcp for bastion group

### DIFF
--- a/ansible/group_vars/bastion.yaml
+++ b/ansible/group_vars/bastion.yaml
@@ -41,5 +41,7 @@ __windmill_users:
 windmill_users: "{{ _windmill_users|combine(__windmill_users, recursive=true) }}"
 
 # NOTE(pabelanger): This is so we can stream console logs with zuul_console.
-_iptables_public_tcp_ports_extra:
-  - 19885
+iptables_allowed_hosts:
+  - address: 38.145.32.61
+    protocol: tcp
+    port: 19885


### PR DESCRIPTION
This is a little more secure, and should limit access to only sf.io
zuul for stream console logs.

Depends-On: https://review.openstack.org/645407
Signed-off-by: Paul Belanger <pabelanger@redhat.com>