### PR TITLE
Give nodepool-builder access to statsd firewall

### DIFF
--- a/ansible/group_vars/statsd.yaml
+++ b/ansible/group_vars/statsd.yaml
@@ -24,6 +24,15 @@ logrotate_configs:
       - daily
       - notifempty
 
+iptables_allowed_hosts:
+  - address: nb01.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: udp
+    port: 8125
+
+  - address: nb02.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: udp
+    port: 8125
+
 __statsd_config_js_graphite_globalPrefix: !vault |
   $ANSIBLE_VAULT;1.1;AES256
   32363765303138633366643962633464643432643436343038663461313363623663343139386161


### PR DESCRIPTION
This is so we can publish stats from nodepool-builder.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>