### PR TITLE
Open firewalls for nodepool-launchers

### DIFF
--- a/ansible/group_vars/statsd.yaml
+++ b/ansible/group_vars/statsd.yaml
@@ -25,11 +25,21 @@ logrotate_configs:
       - notifempty
 
 iptables_allowed_hosts:
+  # nodepool-builders
   - address: nb01.sjc1.vexxhost.zuul-ci.ansible.com
     protocol: udp
     port: 8125
 
   - address: nb02.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: udp
+    port: 8125
+
+  # nodepool-launchers
+  - address: nl01.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: udp
+    port: 8125
+
+  - address: nl02.sjc1.vexxhost.zuul-ci.ansible.com
     protocol: udp
     port: 8125
 

--- a/ansible/group_vars/zookeeper.yaml
+++ b/ansible/group_vars/zookeeper.yaml
@@ -25,11 +25,21 @@ zookeeper_file_myid_src: "{{ windmill_config_git_dest }}/zookeeper/etc/zookeeper
 zookeeper_file_zoo_conf_src: "{{ windmill_config_git_dest }}/zookeeper/etc/zookeeper/conf/zoo.cfg"
 
 iptables_allowed_hosts:
+  # nodepool-builders
   - address: nb01.sjc1.vexxhost.zuul-ci.ansible.com
     protocol: tcp
     port: 2181
 
   - address: nb02.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: tcp
+    port: 2181
+
+  # nodepool-launchers
+  - address: nl01.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: tcp
+    port: 2181
+
+  - address: nl02.sjc1.vexxhost.zuul-ci.ansible.com
     protocol: tcp
     port: 2181
 


### PR DESCRIPTION
This allows nodepool-launchers to access statsd and zookeeper.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>