### PR TITLE
Open firewalls for zuul-executors

### DIFF
--- a/ansible/group_vars/gear.yaml
+++ b/ansible/group_vars/gear.yaml
@@ -169,6 +169,15 @@ logrotate_configs:
       - notifempty
 
 iptables_allowed_hosts:
+  # zuul-executors
+  - address: ze01.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: tcp
+    port: 4730
+
+  - address: ze02.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: tcp
+    port: 4730
+
   # zuul-mergers
   - address: zm01.sjc1.vexxhost.zuul-ci.ansible.com
     protocol: tcp

--- a/ansible/group_vars/statsd.yaml
+++ b/ansible/group_vars/statsd.yaml
@@ -43,6 +43,15 @@ iptables_allowed_hosts:
     protocol: udp
     port: 8125
 
+  # zuul-executors
+  - address: ze01.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: udp
+    port: 8125
+
+  - address: ze02.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: udp
+    port: 8125
+
   # zuul-schedulers
   - address: zs01.sjc1.vexxhost.zuul-ci.ansible.com
     protocol: udp


### PR DESCRIPTION
Now that zuul-executors are online, bring them into production.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>