### PR TITLE
Remove finger_port from zuul.conf executor

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -32,7 +32,6 @@ state_dir = {{ zuul_user_home }}
 
 {% if inventory_hostname in groups['zuul-executor'] %}
 [executor]
-finger_port = 17979
 hostname = {{ hostvars[inventory_hostname].ansible_host }}
 log_config = /etc/zuul/executor-logging.conf
 private_key_file = {{ zuul_user_home }}/.ssh/nodepool_id_rsa


### PR DESCRIPTION
Zuul will now default to a sane port (7900/tcp).

Signed-off-by: Paul Belanger <pabelanger@redhat.com>