### PR TITLE
Fix syntax issue in zuul.conf

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -208,6 +208,9 @@ all:
         ze01.sjc1.vexxhost.zuul-ci.ansible.com:
         ze02.sjc1.vexxhost.zuul-ci.ansible.com:
 
+    # NOTE(pabelanger): We currently only support a single zuul-fingergw host
+    # in this group.  This means, the first host listed will only be used by
+    # our configuration.
     zuul-fingergw:
       hosts:
         zf01.sjc1.vexxhost.zuul-ci.ansible.com:

--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -40,7 +40,7 @@ workspace_root = {{ zuul_user_home }}/workspace
 
 {% if inventory_hostname in groups['zuul-fingergw'] %}
 [fingergw]
-listen_address = {{ hostvars['zf01'].ansible_host }}
+listen_address = {{ hostvars[groups['zuul-fingergw'][0]].ansible_host }}
 log_config = /etc/zuul/fingergw-logging.conf
 user = {{ zuul_user_name }}
 {% endif -%}


### PR DESCRIPTION
Update our configuration to only account for a single zuul-fingergw in
zuul.conf.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>