### PR TITLE
Open port 80/tcp for zuul-web

### DIFF
--- a/ansible/group_vars/zuul-web.yaml
+++ b/ansible/group_vars/zuul-web.yaml
@@ -29,3 +29,6 @@ logrotate_configs:
       - rotate 7
       - daily
       - notifempty
+
+_iptables_public_tcp_ports_extra:
+  - 80


### PR DESCRIPTION
This will allow public HTTP access to nginx. We need to also enable
HTTPS, but requires SSL certs first.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>