### PR TITLE
Remove unused nodepool_file_nodepool_yaml_src

### DIFF
--- a/ansible/group_vars/nodepool-builder.yaml
+++ b/ansible/group_vars/nodepool-builder.yaml
@@ -21,8 +21,6 @@ nodepool_file_nodepool_builder_service_config_manage: true
 nodepool_file_nodepool_builder_service_config_src: nodepool-builder/etc/systemd/system/nodepool-builder.service.d/override.conf.j2
 nodepool_file_nodepool_builder_service_manage: true
 
-nodepool_file_nodepool_yaml_src: "{{ windmill_config_git_dest }}/nodepool/nodepool.yaml.j2"
-
 nodepool_service_nodepool_builder_enabled: true
 nodepool_service_nodepool_builder_manage: true
 nodepool_service_nodepool_builder_state: started


### PR DESCRIPTION
We don't actually need to redefine this, as we can default to what
nodepool group sets.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>