### PR TITLE
Use ansible_pip_virtualenv_symlink to manage /opt/venv/ansible

### DIFF
--- a/ansible/group_vars/bastion.yaml
+++ b/ansible/group_vars/bastion.yaml
@@ -18,6 +18,7 @@ ansible_pip_name:
   - netaddr
 ansible_pip_virtualenv_python: python3
 ansible_pip_virtualenv: /opt/venv/ansible-2.7.9
+ansible_pip_virtualenv_symlink: /opt/venv/ansible
 
 borgbackup_user_groups: windmill
 borgmatic_file_config_yaml_src: "{{ windmill_config_git_dest }}/borgmatic/bastion.yaml.j2"

--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -3,15 +3,6 @@
 
 - hosts: bastion
   tasks:
-    # NOTE(pabelanger): We need to find a better way to manage this. Chances
-    # are we will forget about it everything we upgrade ansible.
-    - name: Symlink /opt/venv/ansible
-      become: true
-      file:
-        src: /opt/venv/ansible-2.7.8
-        dest: /opt/venv/ansible
-        state: link
-
     - name: Create config directory
       file:
         dest: ~/.config


### PR DESCRIPTION
This removes the need to manually symlink directorys, the ansible role
now directly supports this.

Depends-On: https://review.openstack.org/646007
Signed-off-by: Paul Belanger <pabelanger@redhat.com>