### PR TITLE
Add zuul_executor_ansible variable

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -17,11 +17,29 @@ zuul_file_zuul_executor_service_config_manage: true
 zuul_file_zuul_executor_service_config_src: zuul/etc/systemd/system/zuul-executor.service.d/override.conf.j2
 zuul_file_zuul_executor_service_manage: true
 
-zuul_pip_name: zuul[zuul_executor]
-
 zuul_service_zuul_executor_enabled: true
 zuul_service_zuul_executor_manage: true
 zuul_service_zuul_executor_state: started
+
+zuul_executor_ansible:
+  - ansible_pip_name:
+      - ansible==2.5.15
+      - ara
+    ansible_pip_virtualenv_python: python3
+    ansible_pip_virtualenv: /opt/venv/ansible-2.5.15
+    ansible_pip_virtualenv_symlink: /opt/venv/zuul-ansible/2.5
+  - ansible_pip_name:
+      - ansible==2.6.15
+      - ara
+    ansible_pip_virtualenv_python: python3
+    ansible_pip_virtualenv: /opt/venv/ansible-2.6.15
+    ansible_pip_virtualenv_symlink: /opt/venv/zuul-ansible/2.6
+  - ansible_pip_name:
+      - ansible==2.7.9
+      - ara
+    ansible_pip_virtualenv_python: python3
+    ansible_pip_virtualenv: /opt/venv/ansible-2.7.9
+    ansible_pip_virtualenv_symlink: /opt/venv/zuul-ansible/2.7
 
 # openstack.logrotate
 logrotate_configs:

--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -32,8 +32,10 @@ state_dir = {{ zuul_user_home }}
 
 {% if inventory_hostname in groups['zuul-executor'] %}
 [executor]
+ansible_root = /opt/venv/zuul-ansible
 hostname = {{ hostvars[inventory_hostname].ansible_host }}
 log_config = /etc/zuul/executor-logging.conf
+manage_ansible = false
 private_key_file = {{ zuul_user_home }}/.ssh/nodepool_id_rsa
 workspace_root = {{ zuul_user_home }}/workspace
 {% endif -%}


### PR DESCRIPTION
We'll be using this to manage the versions of ansible that
zuul-executors will use once we update to zuul 3.7.0.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>