### PR TITLE
Add zuul_pip_virtualenv_symlink to /opt/venv/zuul

### DIFF
--- a/ansible/group_vars/zuul.yaml
+++ b/ansible/group_vars/zuul.yaml
@@ -19,6 +19,7 @@ zuul_file_zuul_conf_src: "{{ windmill_config_git_dest }}/zuul/zuul.conf.j2"
 zuul_pip_version: 3.7.0
 zuul_pip_virtualenv_python: python3
 zuul_pip_virtualenv: "/opt/venv/zuul-{{ zuul_pip_version }}"
+zuul_pip_virtualenv_symlink: /opt/venv/zuul
 
 zuul_file_executor_logging_conf_manage: false
 zuul_file_fingergw_logging_conf_manage: false


### PR DESCRIPTION
This is helpful to humans wanting to run commands on our zuul servers.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>