### PR TITLE
Allow zuul-scheduler firewall access to database group

### DIFF
--- a/ansible/group_vars/database.yaml
+++ b/ansible/group_vars/database.yaml
@@ -1,0 +1,17 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+---
+iptables_allowed_hosts:
+  # zuul-scheduler
+  - address: zs01.sjc1.vexxhost.zuul-ci.ansible.com
+    protocol: tcp
+    port: 3306


### PR DESCRIPTION
We'll be setting up a connection in zuul.conf to report job results.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>