### PR TITLE
Install certbot to generate SSL certs

### DIFF
--- a/ansible/group_vars/zuul-web.yaml
+++ b/ansible/group_vars/zuul-web.yaml
@@ -10,6 +10,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 ---
+nginx_package_name:
+  - certbot
+  - nginx
+
 # windmill.zuul
 zuul_file_web_logging_conf_manage: true
 


### PR DESCRIPTION
We want to run letsencrypt to manage our SSL certs for nginx.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>