### PR TITLE
Stop running backups on zuul-ci.ansible.com

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -158,14 +158,9 @@ all:
     # NOTE(pabelanger): Remember to create borgmatic configuration and
     # encryption_passphrase each time we add a new host to borg-client
     # group.
-    borg-client:
-      children:
-        bastion: {}
-        zookeeper: {}
+    borg-client: {}
 
-    borg-server:
-      hosts:
-        borg01.ca-ymq-1.vexxhost.zuul-ci.ansible.com:
+    borg-server: {}
 
     # NOTE(pabelanger): We currently only support a single database host in
     # this group.  This means, the first host listed will only be used by our


### PR DESCRIPTION
Prepare to switch our domain from zuul-ci.ansible.com to
zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>