### PR TITLE
Add config / untrusted base projects for ansible tenant

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -5,6 +5,12 @@
 - tenant:
     name: ansible
     source:
+      github.com:
+        config-projects:
+          - ansible/project-config
+        untrusted-projects:
+          - ansible/ansible-zuul-jobs
+
       git.openstack.org:
         untrusted-projects:
           - openstack-infra/zuul-jobs


### PR DESCRIPTION
Start the process of adding jobs to zuul. This requires we also add the
github app to the ansible github org.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>