### PR TITLE
Add fedora-29 diskimage support

### DIFF
--- a/nodepool/elements/nodepool-base/cleanup.d/89-unbound
+++ b/nodepool/elements/nodepool-base/cleanup.d/89-unbound
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+if [ ${DIB_DEBUG_TRACE:-1} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+echo 'nameserver 127.0.0.1' | sudo tee $TARGET_ROOT/etc/resolv.conf

--- a/nodepool/elements/nodepool-base/element-deps
+++ b/nodepool/elements/nodepool-base/element-deps
@@ -1,0 +1,2 @@
+package-installs
+zuul-worker

--- a/nodepool/elements/nodepool-base/finalise.d/89-glean
+++ b/nodepool/elements/nodepool-base/finalise.d/89-glean
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright (C) 2011-2013 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=set setu setpipefail indent
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+case "$DIB_INIT_SYSTEM" in
+    systemd)
+        glean_path_dib="/etc/systemd/system/glean@.service.d"
+        mkdir -p $glean_path_dib
+        nodepool_base="$(dirname $0)/../glean@.service.d"
+        cp -RP $nodepool_base/override.conf $glean_path_dib/override.conf
+        ;;
+    *)
+        echo "Skipping glean systemd configuration"
+        ;;
+esac

--- a/nodepool/elements/nodepool-base/finalise.d/89-unbound
+++ b/nodepool/elements/nodepool-base/finalise.d/89-unbound
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright (C) 2011-2013 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=set setu setpipefail indent
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+NODEPOOL_STATIC_NAMESERVER_V6=${NODEPOOL_STATIC_NAMESERVER_V6:-2620:0:ccc::2}
+NODEPOOL_STATIC_NAMESERVER_V4=${NODEPOOL_STATIC_NAMESERVER_V4:-208.67.222.222}
+NODEPOOL_STATIC_NAMESERVER_V6_FALLBACK=${NODEPOOL_STATIC_NAMESERVER_V6_FALLBACK:-2001:4860:4860::8888}
+NODEPOOL_STATIC_NAMESERVER_V4_FALLBACK=${NODEPOOL_STATIC_NAMESERVER_V4_FALLBACK:-8.8.8.8}
+dd of=/tmp/forwarding.conf <<EOF
+forward-zone:
+  name: "."
+  forward-addr: $NODEPOOL_STATIC_NAMESERVER_V6
+  forward-addr: $NODEPOOL_STATIC_NAMESERVER_V6_FALLBACK
+  forward-addr: $NODEPOOL_STATIC_NAMESERVER_V4
+  forward-addr: $NODEPOOL_STATIC_NAMESERVER_V4_FALLBACK
+EOF
+
+mv /tmp/forwarding.conf /etc/unbound/conf.d
+chown root:root /etc/unbound/conf.d/forwarding.conf
+chmod 0644 /etc/unbound/conf.d/forwarding.conf

--- a/nodepool/elements/nodepool-base/glean@.service.d/override.conf
+++ b/nodepool/elements/nodepool-base/glean@.service.d/override.conf
@@ -1,0 +1,4 @@
+[Service]
+Environment="ARGS=--interface %I --skip-dns --debug"
+StandardError=journal+console
+StandardOutput=journal+console

--- a/nodepool/elements/nodepool-base/install.d/10-packages
+++ b/nodepool/elements/nodepool-base/install.d/10-packages
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=setu setpipefail
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+# NOTE(pabelanger): $YUM will now default to dnf, but we still support
+# centos-7.
+YUM=${YUM:-yum}
+
+if [[ "$DISTRO_NAME" =~ (centos) ]] ; then
+    # NOTE(pabelanger): We do this so we don't enable EPEL by default.
+    $YUM -y install --enablerepo=epel haveged
+fi

--- a/nodepool/elements/nodepool-base/install.d/10-pip-packages
+++ b/nodepool/elements/nodepool-base/install.d/10-pip-packages
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=setu setpipefail
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+# NOTE(pabelanger): This is to work around a bug in the zuul-jobs tox role, this
+# is because ensure-tox installs into ~/.local/bin however ansible doesn't
+# incude that within PATH by default.
+pip install tox

--- a/nodepool/elements/nodepool-base/package-installs.yaml
+++ b/nodepool/elements/nodepool-base/package-installs.yaml
@@ -1,0 +1,5 @@
+---
+haveged:
+ntp:
+ntpdate:
+unbound:

--- a/nodepool/elements/nodepool-base/pkg-map
+++ b/nodepool/elements/nodepool-base/pkg-map
@@ -1,0 +1,11 @@
+{
+  "distro": {
+    "centos": {
+      "haveged": ""
+    }
+  },
+  "default": {
+    "haveged": "haveged",
+    "unbound": "unbound"
+  }
+}

--- a/nodepool/elements/nodepool-base/post-install.d/79-simple-init
+++ b/nodepool/elements/nodepool-base/post-install.d/79-simple-init
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=set setu setpipefail indent
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+case "$DIB_INIT_SYSTEM" in
+    systemd)
+        if [ ${DISTRO_NAME} = "fedora" -a ${DIB_RELEASE} -ge 28 ]; then
+            # NOTE(pabelanger): Until glean support networkmaster, use
+            # deprecated network-scripts.
+            # https://review.openstack.org/618964/
+            dnf install -y network-scripts
+        fi
+        ;;
+    *)
+        echo "Skipping fedora simple-init workaround"
+        ;;
+esac

--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -24,6 +24,8 @@ providers:
     # hostname length under 64.
     hostname-format: '{label.name}-vexxhost-mtl1-{node.id}'
     diskimages: &provider_diskimages
+      - name: fedora-29
+        config-drive: true
       - name: ubuntu-bionic
         config-drive: true
     pools:
@@ -34,6 +36,11 @@ providers:
       - name: v2-highcpu-1
         max-servers: 8
         labels: &provider_pools_v2_highcpu_1_labels
+          - name: fedora-29-1vcpu
+            flavor-name: v2-highcpu-1
+            diskimage: fedora-29
+            boot-from-volume: true
+            volume-size: 80
           - name: ubuntu-bionic-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: ubuntu-bionic
@@ -41,4 +48,5 @@ providers:
             volume-size: 80
 
 diskimages:
+  - name: fedora-29
   - name: ubuntu-bionic

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -23,6 +23,8 @@ providers:
     # hostname length under 64.
     hostname-format: '{label.name}-vexxhost-sjc1-{node.id}'
     diskimages: &provider_diskimages
+      - name: fedora-29
+        config-drive: true
       - name: ubuntu-bionic
         config-drive: true
     pools:
@@ -33,11 +35,18 @@ providers:
       - name: v2-highcpu-1
         max-servers: 8
         labels: &provider_pools_v2_highcpu_1_labels
+          - name: fedora-29-1vcpu
+            flavor-name: v2-highcpu-1
+            diskimage: fedora-29
+            boot-from-volume: true
+            volume-size: 80
           - name: ubuntu-bionic-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: ubuntu-bionic
             boot-from-volume: true
             volume-size: 80
 
+
 diskimages:
+  - name: fedora-29
   - name: ubuntu-bionic

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -21,6 +21,20 @@ providers:
     diskimages: *provider_diskimages
 
 diskimages:
+  - name: fedora-29
+    elements:
+      - fedora-minimal
+      - growroot
+      - nodepool-base
+      - openssh-server
+      - simple-init
+      - vm
+    env-vars:
+      DIB_CHECKSUM: '1'
+      DIB_GRUB_TIMEOUT: '0'
+      DIB_RELEASE: '29'
+      QEMU_IMG_OPTIONS: compat=0.10
+
   - name: ubuntu-bionic
     elements:
       - ubuntu-minimal


### PR DESCRIPTION
We'll want to start testing using fedora-29 nodes, this start building
images and uploading them into clouds.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>