### PR TITLE
Rebuild statsd01.sjc1.vexxhost.zuul.ansible.com

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -58,11 +58,11 @@ all:
         public_ipv6: ''
 
     statsd01.sjc1.vexxhost.zuul.ansible.com:
-      ansible_host: 38.108.68.105
-      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIA9SfExmj54EAYNj3oqqIYC/YyF8kkkKeiedUrRnlviZ
+      ansible_host: 38.108.68.137
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIIVaj6gc20eZ0BKMa8OxGIVgbnOAYlBEbZq1zybaPMVY
       ansible_user: windmill
       node_attributes:
-        public_ipv4: 38.108.68.105
+        public_ipv4: 38.108.68.137
         public_ipv6: ''
 
     zk01.sjc1.vexxhost.zuul.ansible.com:


### PR DESCRIPTION
This is to pickup our UID / GID fixes in windmill-ops.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>