### PR TITLE
Add emergency.yaml inventory

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -6,7 +6,7 @@
 callback_plugins = /opt/venv/ansible/lib/python3.6/site-packages/ara/plugins/callbacks
 callback_whitelist = profile_tasks, timer
 forks = 20
-inventory = ~/.config/windmill/ansible/hosts.yaml
+inventory = ~/.config/windmill/ansible/hosts.yaml,/etc/ansible/hosts/emergency.yaml
 retry_files_enabled = false
 stdout_callback = yaml
 vault_password_file = ~/.ansible_vault


### PR DESCRIPTION
This allows us to manually disable hosts out side of git.  Helpful when
we need to quickly do so.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>