### PR TITLE
Rebuild zk01.sjc1.vexxhost.zuul.ansible.com

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -122,11 +122,11 @@ all:
         public_ipv6: ''
 
     zs01.sjc1.vexxhost.zuul.ansible.com:
-      ansible_host: 38.108.68.139
-      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIODmTUqCV99yT9K/7yF9v7aIWtAO6mcn8WtqCP2TguZd
+      ansible_host: 38.108.68.61
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAICknumOQvR11O5j2BCACtrgcXxloen//i9GGmENDCp8o
       ansible_user: windmill
       node_attributes:
-        public_ipv4: 38.108.68.139
+        public_ipv4: 38.108.68.61
         public_ipv6: ''
 
     zw01.sjc1.vexxhost.zuul.ansible.com:


### PR DESCRIPTION
This picks up our UID / GID fixes from windmill-ops.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>