### PR TITLE
Disable fedora-29 DIBs

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -22,6 +22,7 @@ providers:
 
 diskimages:
   - name: fedora-29
+    pause: true
     elements:
       - fedora-minimal
       - growroot


### PR DESCRIPTION
This seems to be broken current, stop nodepool-builder from keep
building it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>