### PR TITLE
Rework zuul-executor paths for ansible virtualenv

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -26,20 +26,20 @@ zuul_executor_ansible:
       - ansible==2.5.15
       - ara
     ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/ansible-2.5.15
-    ansible_pip_virtualenv_symlink: /opt/venv/zuul-ansible/2.5
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.5.15
+    ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.5
   - ansible_pip_name:
       - ansible==2.6.15
       - ara
     ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/ansible-2.6.15
-    ansible_pip_virtualenv_symlink: /opt/venv/zuul-ansible/2.6
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.6.15
+    ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.6
   - ansible_pip_name:
       - ansible==2.7.9
       - ara
     ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/ansible-2.7.9
-    ansible_pip_virtualenv_symlink: /opt/venv/zuul-ansible/2.7
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.7.9
+    ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.7
 
 # openstack.logrotate
 logrotate_configs:

--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -32,11 +32,13 @@ state_dir = {{ zuul_user_home }}
 
 {% if inventory_hostname in groups['zuul-executor'] %}
 [executor]
-ansible_root = /opt/venv/zuul-ansible
+ansible_root = /var/lib/zuul/venv/ansible
 hostname = {{ hostvars[inventory_hostname].ansible_host }}
 log_config = /etc/zuul/executor-logging.conf
 manage_ansible = false
 private_key_file = {{ zuul_user_home }}/.ssh/nodepool_id_rsa
+trusted_ro_paths = /opt/venv/zuul-ansible
+untrusted_ro_paths = /opt/venv/zuul-ansible
 workspace_root = {{ zuul_user_home }}/workspace
 {% endif -%}
 


### PR DESCRIPTION
Our pervious attempt didn't take into account the need to bind-mount
ansible into bwrap.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>