### PR TITLE
Set exclude-unprotected-branches true for ansible tenant

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -4,6 +4,9 @@
 #
 - tenant:
     name: ansible
+    # NOTE(pabelanger): By default, we don't want to load any branches
+    # that are unprotected.
+    exclude-unprotected-branches: true
     source:
       github.com:
         config-projects:


### PR DESCRIPTION
We only want zuul to run jobs on protected branches, this helps to limit
projects from breaking zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>