### PR TITLE
Set min-ready: 0 for labels

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -12,10 +12,8 @@ labels:
   - name: centos-7-1vcpu
     max-ready-age: 600
   - name: fedora-29-1vcpu
-    min-ready: 1
     max-ready-age: 600
   - name: ubuntu-bionic-1vcpu
-    min-ready: 1
     max-ready-age: 600
 
 providers:


### PR DESCRIPTION
There is a cost to keep a node ready, so default to 0

Signed-off-by: Paul Belanger <pabelanger@redhat.com>