### PR TITLE
Setup diskimage_builder_pip_version to 2.19.0

### DIFF
--- a/ansible/group_vars/nodepool-builder.yaml
+++ b/ansible/group_vars/nodepool-builder.yaml
@@ -11,6 +11,7 @@
 # under the License.
 ---
 # windmill.diskimage-builder
+diskimage_builder_pip_version: 2.19.0
 diskimage_builder_pip_virtualenv_python: python3
 diskimage_builder_pip_virtualenv: "{{ nodepool_pip_virtualenv }}"
 


### PR DESCRIPTION
See if this release allows us to build fedora-minimal images again.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>