### PR TITLE
Unpause fedora-29 images

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -42,7 +42,6 @@ diskimages:
       QEMU_IMG_OPTIONS: compat=0.10
 
   - name: fedora-29
-    pause: true
     elements:
       - fedora-minimal
       - growroot


### PR DESCRIPTION
Now that we have downgraded diskimage-builder, try building
fedora-minimal again.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>