### PR TITLE
Upload images to limestone nodepool provider

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -6,9 +6,9 @@ elements-dir: /etc/nodepool/elements
 images-dir: /opt/nodepool/images
 
 providers:
-  - name: vexxhost-ansible-network-mtl1
-    cloud: vexxhost-ansible-network
-    region-name: 'ca-ymq-1'
+  - name: limestone-us-dfw-1
+    cloud: limestone
+    region-name: us-dfw-1
     rate: 0.001
     diskimages: &provider_diskimages
       - name: centos-7
@@ -17,6 +17,18 @@ providers:
         config-drive: true
       - name: ubuntu-bionic
         config-drive: true
+
+  - name: limestone-us-slc
+    cloud: limestone
+    region-name: us-slc
+    rate: 0.001
+    diskimages: *provider_diskimages
+
+  - name: vexxhost-ansible-network-mtl1
+    cloud: vexxhost-ansible-network
+    region-name: 'ca-ymq-1'
+    rate: 0.001
+    diskimages: *provider_diskimages
 
   - name: vexxhost-ansible-network-sjc1
     cloud: vexxhost-ansible-network


### PR DESCRIPTION
Man, I did this backwards. That is what I get for rushing.  The order
should have been, add provider to builder first, then launcher.  Should
really document this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>