### PR TITLE
Disable vexxhost-ansible-network nodepool providers

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -43,7 +43,7 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: v2-highcpu-1
-        max-servers: 8
+        max-servers: 0
         labels: &provider_pools_v2_highcpu_1_labels
           - name: centos-7-1vcpu
             flavor-name: v2-highcpu-1

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -43,7 +43,7 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: v2-highcpu-1
-        max-servers: 8
+        max-servers: 0
         labels: &provider_pools_v2_highcpu_1_labels
           - name: centos-7-1vcpu
             flavor-name: v2-highcpu-1


### PR DESCRIPTION
This allows us to start running jobs on limestone.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>