### PR TITLE
Remove image uploads from vexxhost-ansible-network

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -44,22 +44,7 @@ providers:
       # Ansible org.
       - name: v2-highcpu-1
         max-servers: 0
-        labels: &provider_pools_v2_highcpu_1_labels
-          - name: centos-7-1vcpu
-            flavor-name: v2-highcpu-1
-            diskimage: centos-7
-            boot-from-volume: true
-            volume-size: 80
-          - name: fedora-29-1vcpu
-            flavor-name: v2-highcpu-1
-            diskimage: fedora-29
-            boot-from-volume: true
-            volume-size: 80
-          - name: ubuntu-bionic-1vcpu
-            flavor-name: v2-highcpu-1
-            diskimage: ubuntu-bionic
-            boot-from-volume: true
-            volume-size: 80
+        labels: []
 
   - name: limestone-us-dfw-1
     cloud: limestone

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -44,23 +44,7 @@ providers:
       # Ansible org.
       - name: v2-highcpu-1
         max-servers: 0
-        labels: &provider_pools_v2_highcpu_1_labels
-          - name: centos-7-1vcpu
-            flavor-name: v2-highcpu-1
-            diskimage: centos-7
-            boot-from-volume: true
-            volume-size: 80
-          - name: fedora-29-1vcpu
-            flavor-name: v2-highcpu-1
-            diskimage: fedora-29
-            boot-from-volume: true
-            volume-size: 80
-          - name: ubuntu-bionic-1vcpu
-            flavor-name: v2-highcpu-1
-            diskimage: ubuntu-bionic
-            boot-from-volume: true
-            volume-size: 80
-
+        labels: []
 
 diskimages:
   - name: centos-7


### PR DESCRIPTION
Prepare to remove vexxhost-ansible-network from nodepool, as we now are
able to run jobs on limestone.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>