### PR TITLE
Remove diskimages from vexxhost-ansible-network

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -30,21 +30,7 @@ providers:
     # NOTE(pabelanger): Strip ansible-network from provider.name to keep
     # hostname length under 64.
     hostname-format: '{label.name}-vexxhost-mtl1-{node.id}'
-    diskimages: &provider_diskimages
-      - name: centos-7
-        config-drive: true
-      - name: fedora-29
-        config-drive: true
-      - name: ubuntu-bionic
-        config-drive: true
-    pools:
-      # NOTE(pabelanger): Please contact pabelanger before making changes to
-      # this pool, especially increasing max-servers or changing labels. There
-      # is a real world financial cost in doing so that is charged to the
-      # Ansible org.
-      - name: v2-highcpu-1
-        max-servers: 0
-        labels: []
+    diskimages: []
 
   - name: limestone-us-dfw-1
     cloud: limestone

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -30,21 +30,7 @@ providers:
     # NOTE(pabelanger): Strip ansible-network from provider.name to keep
     # hostname length under 64.
     hostname-format: '{label.name}-vexxhost-sjc1-{node.id}'
-    diskimages: &provider_diskimages
-      - name: centos-7
-        config-drive: true
-      - name: fedora-29
-        config-drive: true
-      - name: ubuntu-bionic
-        config-drive: true
-    pools:
-      # NOTE(pabelanger): Please contact pabelanger before making changes to
-      # this pool, especially increasing max-servers or changing labels. There
-      # is a real world financial cost in doing so that is charged to the
-      # Ansible org.
-      - name: v2-highcpu-1
-        max-servers: 0
-        labels: []
+    diskimages: []
 
 diskimages:
   - name: centos-7

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -28,13 +28,13 @@ providers:
     cloud: vexxhost-ansible-network
     region-name: 'ca-ymq-1'
     rate: 0.001
-    diskimages: *provider_diskimages
+    diskimages: []
 
   - name: vexxhost-ansible-network-sjc1
     cloud: vexxhost-ansible-network
     region-name: sjc1
     rate: 0.001
-    diskimages: *provider_diskimages
+    diskimages: []
 
 diskimages:
   - name: centos-7


### PR DESCRIPTION
This is our next step to remove vexxhost-ansible-network from nodepool.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>