### PR TITLE
Switch ansible_python_interpreter to python3

### DIFF
--- a/tests/playbooks/bastion.yaml
+++ b/tests/playbooks/bastion.yaml
@@ -5,6 +5,7 @@
       add_host:
         name: "{{ site_windmill_config_bastion.name }}"
         ansible_host: "{{ site_windmill_config_bastion.fqdn }}"
+        ansible_python_interpreter: python3
         ansible_user: "{{ site_windmill_config_bastion.ssh_username }}"
         groups: bastion
 


### PR DESCRIPTION
Zuul 3.7.0 fixed a bug where we couldn't set this value.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>