### PR TITLE
Allow zuul.ansible.com access to bastion group firewall

### DIFF
--- a/ansible/group_vars/bastion.yaml
+++ b/ansible/group_vars/bastion.yaml
@@ -44,6 +44,9 @@ windmill_users: "{{ _windmill_users|combine(__windmill_users, recursive=true) }}
 
 # NOTE(pabelanger): This is so we can stream console logs with zuul_console.
 iptables_allowed_hosts:
-  - address: 38.145.32.61
+  - address: ze01.sjc1.vexxhost.zuul.ansible.com
+    protocol: tcp
+    port: 19885
+  - address: ze02.sjc1.vexxhost.zuul.ansible.com
     protocol: tcp
     port: 19885


### PR DESCRIPTION
This allows zuul_console access for streaming logs in our promote /
periodic pipelines.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>