### PR TITLE
Add ansible/project-config as required project

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -7,6 +7,7 @@
     allowed-projects:
       - github.com/ansible-network/windmill-config
     required-projects:
+      - name: github.com/ansible/project-config
       - name: git.openstack.org/openstack/windmill
       - name: git.openstack.org/openstack/windmill-backup
       - name: git.openstack.org/openstack/windmill-ops


### PR DESCRIPTION
We plan on moving our nodepool / zuul configuration into that repo, this
starts checking out ansible/project-config on bastion host.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>