### PR TITLE
Add ansible-network/arista_eos to ansible tenant

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -12,7 +12,11 @@
         config-projects:
           - ansible/project-config
         untrusted-projects:
+          # Order matters, load common job repos first
           - ansible/ansible-zuul-jobs
+          # After this point, sorting projects alphabetically will help
+          # merge conflicts
+          - ansible-network/arista_eos
           - ansible-network/windmill-config
 
       git.openstack.org:


### PR DESCRIPTION
We are migrating this from sf.io, into ansible.zuul.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>