### PR TITLE
Add ansible-network/resource_module_builder to ansible zuul tenant

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -17,6 +17,7 @@
           # After this point, sorting projects alphabetically will help
           # merge conflicts
           - ansible-network/arista_eos
+          - ansible-network/resource_module_builder
           - ansible-network/sandbox
           - ansible-network/windmill-config
 


### PR DESCRIPTION
We plan on gating this project with zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>