### PR TITLE
Add ansible-network/packet-ci-cloud to ansible zuul tenant

### DIFF
--- a/zuul/main.yaml
+++ b/zuul/main.yaml
@@ -17,6 +17,7 @@
           # After this point, sorting projects alphabetically will help
           # merge conflicts
           - ansible-network/arista_eos
+          - ansible-network/packet-ci-cloud
           - ansible-network/resource_module_builder
           - ansible-network/sandbox
           - ansible-network/windmill-config


### PR DESCRIPTION
We'd like to gate jobs using zuul, add it to ansible zuul tenant.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>