### PR TITLE
Allow ansible/project-config to run windmill-config-deploy

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -6,6 +6,7 @@
     post-run: tests/playbooks/post.yaml
     allowed-projects:
       - github.com/ansible-network/windmill-config
+      - github.com/ansible/project-config
     required-projects:
       - name: github.com/ansible/project-config
       - name: git.openstack.org/openstack/windmill


### PR DESCRIPTION
This is so we can move nodepool / zuul user facing confiuration to
ansible/project-config.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>