### PR TITLE
Use ansible_host for add_host task

### DIFF
--- a/tests/playbooks/bastion.yaml
+++ b/tests/playbooks/bastion.yaml
@@ -2,13 +2,15 @@
 - hosts: localhost
   vars:
     bastion_hostname: bastion01.sjc1.vexxhost.zuul.ansible.com
+    bastion_ansible_host: 38.108.68.150
     bastion_ssh_user: windmill
-    bastion_ssh_host_key: "{{ bastion_hostname }} ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJwUngYI3KGYjZ3kFlX11bo3OS/ZS92wKQGEnIoQjxgS"
+    bastion_ssh_host_key: "{{ bastion_hostname }},{{ bastion_ansible_host}} ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJwUngYI3KGYjZ3kFlX11bo3OS/ZS92wKQGEnIoQjxgS"
 
   tasks:
     - name: Add bastion server
       add_host:
         name: "{{ bastion_hostname }}"
+        ansible_host: "{{ bastion_ansible_host }}"
         ansible_python_interpreter: python3
         ansible_user: "{{ bastion_ssh_user }}"
         groups: bastion


### PR DESCRIPTION
It seems there might be a bug in zuul_console where dns based hosts
don't stream logs properly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>