### PR TITLE
Add ansible-network/windmill-config as require-project

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -8,6 +8,7 @@
       - ansible-network/windmill-config
       - ansible/project-config
     required-projects:
+      - name: github.com/ansible-network/windmill-config
       - name: github.com/ansible/project-config
       - name: git.openstack.org/openstack/windmill
       - name: git.openstack.org/openstack/windmill-backup


### PR DESCRIPTION
This is needed when we run promote jobs from ansible/project-config.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>