### PR TITLE
Bump zuul-executor to ansible 2.6.16

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -30,11 +30,11 @@ zuul_executor_ansible:
     ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.5.15
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.5
   - ansible_pip_name:
-      - ansible==2.6.15
+      - ansible==2.6.16
       - ara
       - openstacksdk
     ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.6.15
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.6.16
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.6
   - ansible_pip_name:
       - ansible==2.7.9


### PR DESCRIPTION
This upgrades the stable-2.6 version of ansible to 2.6.16 for zuul jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>