### PR TITLE
Remove ubuntu-bionic images from nodepool providers

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -17,8 +17,6 @@ labels:
     max-ready-age: 600
   - name: fedora-29-4vcpu
     max-ready-age: 600
-  - name: ubuntu-bionic-1vcpu
-    max-ready-age: 600
 
 providers:
   - name: vexxhost-ansible-network-mtl1

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -17,8 +17,6 @@ labels:
     max-ready-age: 600
   - name: fedora-29-4vcpu
     max-ready-age: 600
-  - name: ubuntu-bionic-1vcpu
-    max-ready-age: 600
 
 providers:
   - name: vexxhost-ansible-network-sjc1

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -15,8 +15,6 @@ providers:
         config-drive: true
       - name: fedora-29
         config-drive: true
-      - name: ubuntu-bionic
-        config-drive: true
 
   - name: limestone-us-slc
     cloud: limestone


### PR DESCRIPTION
Right now we don't actually use this image, and it is likely broken.
Remove it for now until a project actually needs it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>