### PR TITLE
Set proxy_read_timeout to 1 hour

### DIFF
--- a/zuul/etc/nginx/sites-available/dashboard-ssl.j2
+++ b/zuul/etc/nginx/sites-available/dashboard-ssl.j2
@@ -15,5 +15,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
+
+    proxy_read_timeout 1h;
   }
 }


### PR DESCRIPTION
It seems if we don't get any traffic from console log after 60 seconds
our websocket connection will close. We should see if we can configure
zuul to do keep alives, but for now bump the timeout to 1hr.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>