### PR TITLE
Fix typo with windmill-config-promote-base job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -3,7 +3,7 @@
     name: windmill-config-promote-base
     abstract: true
     pre-run: tests/playbooks/promote-base/pre.yaml
-    post-run: tests/playbooks/deploy/post.yaml
+    post-run: tests/playbooks/promote-base/post.yaml
     allowed-projects:
       - ansible-network/windmill-config
       - ansible/project-config


### PR DESCRIPTION
Our post-run playbook was in the wrong location.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>