### PR TITLE
Use tox from OS

### DIFF
--- a/tests/playbooks/project-config-github-promote/run.yaml
+++ b/tests/playbooks/project-config-github-promote/run.yaml
@@ -3,10 +3,16 @@
 
 - hosts: bastion
   tasks:
+    - name: Ensure tox is installed
+      package:
+        become: true
+        name: tox
+        state: present
+
     - name: Bootstrap tox environment
       args:
         chdir: ~/src/github.com/ansible/project-config
-      shell: "{{ ansible_user_dir }}/.local/bin/tox -v -evenv --notest"
+      shell: tox -v -evenv --notest
 
     - name: Promote ansible/project-config github/projects.yaml
       args:


### PR DESCRIPTION
There is no need to use pip installed version of tox.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>