### PR TITLE
Only run project-config-github-promote on specific files

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -31,3 +31,6 @@
     run: tests/playbooks/project-config-github-promote/run.yaml
     required-projects:
       - name: github.com/ansible/project-config
+    files:
+      - github/projects.yaml
+      - tools/manage-projects.py


### PR DESCRIPTION
We can limit when we run this job, based on the files attribute. This
helps cut down on the amount of resources we use.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>