### PR TITLE
Revert "Update connection-type for vyos-1.1.8 cloud-image"

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -35,7 +35,6 @@ providers:
     cloud-images:
       - name: vyos-1.1.8-20190407
         config-drive: true
-        connection-type: network_cli
     pools:
       # NOTE(pabelanger): Please contact pabelanger before making changes to
       # this pool, especially increasing max-servers or changing labels. There


### PR DESCRIPTION
There is a bug in nodepool that we first need to fix.

This reverts commit e0ed70034e4a1bb4bb97e4f856d437dd6bc4f13b.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>