### PR TITLE
Install zuul-executor dependencies

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -17,6 +17,8 @@ zuul_file_zuul_executor_service_config_manage: true
 zuul_file_zuul_executor_service_config_src: zuul/etc/systemd/system/zuul-executor.service.d/override.conf.j2
 zuul_file_zuul_executor_service_manage: true
 
+zuul_pip_name: zuul[zuul_executor]
+
 zuul_service_zuul_executor_enabled: true
 zuul_service_zuul_executor_manage: true
 zuul_service_zuul_executor_state: started


### PR DESCRIPTION
This is still needed to pull ara into zuul-executor virtualenv.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>