### PR TITLE
Install zuul-executor dependencies

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -17,6 +17,8 @@ zuul_file_zuul_executor_service_config_manage: true
 zuul_file_zuul_executor_service_config_src: zuul/etc/systemd/system/zuul-executor.service.d/override.conf.j2
 zuul_file_zuul_executor_service_manage: true
 
+zuul_pip_name: zuul[zuul_executor]
+
 zuul_service_zuul_executor_enabled: true
 zuul_service_zuul_executor_manage: true
 zuul_service_zuul_executor_state: started

--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -38,8 +38,8 @@ ansible_root = /var/lib/zuul/venv/ansible
 log_config = /etc/zuul/executor-logging.conf
 manage_ansible = false
 private_key_file = {{ zuul_user_home }}/.ssh/nodepool_id_rsa
-trusted_ro_paths = /opt/venv/zuul-ansible
-untrusted_ro_paths = /opt/venv/zuul-ansible
+trusted_ro_paths = /opt/venv
+untrusted_ro_paths = /opt/venv
 workspace_root = {{ zuul_user_home }}/workspace
 
 {% endif -%}


### PR DESCRIPTION
This is still needed to pull ara into zuul-executor virtualenv.

Also update zuul.conf so we can allow bwrap access to ara in
/opt/venv/zuul. Note, we'll be patching zuul to not do this in the
future.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>