### PR TITLE
Add public_ipv6 for bastion01

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -7,7 +7,7 @@ all:
       ansible_user: windmill
       node_attributes:
         public_ipv4: 38.108.68.150
-        public_ipv6: ''
+        public_ipv6: 2604:e100:3:0:f816:3eff:fe71:4f45
 
     borg01.ca-ymq-1.vexxhost.zuul.ansible.com:
       ansible_host: 199.204.45.30


### PR DESCRIPTION
We now have ipv6 in vexxhost sjc1, lets add it to bastion and confirm
dns promote job is working properly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>