### PR TITLE
Revert "Start testing mitogen_linear"

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -13,9 +13,6 @@ gathering = smart
 inventory = ~/.config/windmill/ansible/hosts.yaml,/etc/ansible/hosts/emergency.yaml
 retry_files_enabled = false
 stdout_callback = yaml
-strategy = mitogen_linear
-# TODO(pabelanger): Make this more dynamic, as python versions change.
-strategy_plugins = /opt/venv/ansible/lib/python3.6/site-packages/ansible_mitogen/plugins/strategy
 vault_password_file = ~/.ansible_vault
 
 [ssh_connection]


### PR DESCRIPTION
I'm going to work with ansible-core team to see why we are getting
SIGPIPE from ansible-playbook. However, mitogen didn't seem to have that
issue.

This reverts commit 99e42083dbd3e4cf80b82a5c2f436e1ad0e38ca5.