### PR TITLE
Set managing ssh_args in ansible.cfg

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -16,5 +16,6 @@ stdout_callback = yaml
 vault_password_file = ~/.ansible_vault
 
 [ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=60
 pipelining = true
 retries = 3


### PR DESCRIPTION
We are seeing some SSH issues on our windmill-deploy job. Add some
default ssh_args settings to see if this helps things.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>