### PR TITLE
Bump boot-timeout to 300 seconds

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -26,7 +26,7 @@ providers:
   - name: vexxhost-ca-ymq-1
     cloud: vexxhost
     region-name: ca-ymq-1
-    boot-timeout: 120
+    boot-timeout: 300
     launch-timeout: 300
     rate: 0.001
     diskimages: &provider_vexxhost_diskimages
@@ -92,7 +92,7 @@ providers:
   - name: vexxhost-sjc1
     cloud: vexxhost
     region-name: sjc1
-    boot-timeout: 120
+    boot-timeout: 300
     launch-timeout: 300
     rate: 0.001
     diskimages: *provider_vexxhost_diskimages


### PR DESCRIPTION
Our network vms need a little more time to come online, before we abort
launching them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>