### PR TITLE
Disable config-drive for eos images

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -36,7 +36,8 @@ providers:
         config-drive: true
     cloud-images: &provider_vexxhost_cloud-images
       - name: vEOS-4.20.10M-20190501
-        config-drive: true
+        # NOTE(pabelanger): This seems to mess up the boot-loader for eos
+        config-drive: false
       - name: vyos-1.1.8-20190407
         config-drive: true
     pools:
@@ -54,7 +55,6 @@ providers:
           - name: eos-4.20.10
             flavor-name: v1-standard-2
             cloud-image: vEOS-4.20.10M-20190501
-            key-name: infra-root-keys
           - name: centos-7-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: centos-7


### PR DESCRIPTION
This seems to mess up the bootloader for eos.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>