### PR TITLE
Switch to DIB_INSTALLTYPE_pip_and_virtualenv: 'package'

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -76,6 +76,7 @@ diskimages:
     env-vars:
       DIB_CHECKSUM: '1'
       DIB_GRUB_TIMEOUT: '0'
+      DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
       DIB_RELEASE: '29'
       QEMU_IMG_OPTIONS: compat=0.10
 
@@ -92,4 +93,5 @@ diskimages:
       TMPDIR: /opt/nodepool/tmp
       DIB_CHECKSUM: '1'
       DIB_DEBIAN_COMPONENTS: 'main,universe'
+      DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
       QEMU_IMG_OPTIONS: compat=0.10


### PR DESCRIPTION
Stop installing the latest and greatest pip / virtualenv from pypi. We
should be testing against the base distro packages.

NOTE: centos-7 still uses source installs, until we can enable epel.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>