### PR TITLE
Add fedora-30 to nodepool-builders

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -15,6 +15,8 @@ providers:
         config-drive: true
       - name: fedora-29
         config-drive: true
+      - name: fedora-30
+        config-drive: true
       - name: ubuntu-bionic
         config-drive: true
 
@@ -78,6 +80,21 @@ diskimages:
       DIB_GRUB_TIMEOUT: '0'
       DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
       DIB_RELEASE: '29'
+      QEMU_IMG_OPTIONS: compat=0.10
+
+  - name: fedora-30
+    elements:
+      - fedora-minimal
+      - growroot
+      - nodepool-base
+      - openssh-server
+      - simple-init
+      - vm
+    env-vars:
+      DIB_CHECKSUM: '1'
+      DIB_GRUB_TIMEOUT: '0'
+      DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
+      DIB_RELEASE: '30'
       QEMU_IMG_OPTIONS: compat=0.10
 
   - name: ubuntu-bionic


### PR DESCRIPTION
Start building fedora-30 images, we still need to all them to
nodepool-laucher.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>