### PR TITLE
Bring online zm03.sjc1.vexxhost.zuul.ansible.com

### DIFF
--- a/tests/playbooks/windmill-config-dns-promote/route53.yaml
+++ b/tests/playbooks/windmill-config-dns-promote/route53.yaml
@@ -12,7 +12,7 @@
         zone: zuul.ansible.com
       when: hostvars[item].node_attributes.public_ipv4
       with_inventory_hostnames:
-        - all
+        - all:!bastion
 
     - name: Update route53 AAAA records
       route53:
@@ -25,4 +25,4 @@
         zone: zuul.ansible.com
       when: hostvars[item].node_attributes.public_ipv6
       with_inventory_hostnames:
-        - all
+        - all:!bastion


### PR DESCRIPTION
This will be our replacement to zm02.sjc1.vexxhost.zuul.ansible.com,
given the HDD is in read-only mode, we may have lost data. Just reboot a
new server to take its place.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>