### PR TITLE
Don't run route53 on disabled group

### DIFF
--- a/tests/playbooks/windmill-config-dns-promote/route53.yaml
+++ b/tests/playbooks/windmill-config-dns-promote/route53.yaml
@@ -12,7 +12,7 @@
         zone: zuul.ansible.com
       when: hostvars[item].node_attributes.public_ipv4
       with_inventory_hostnames:
-        - all
+        - all:!disabled
 
     - name: Update route53 AAAA records
       route53:
@@ -25,4 +25,4 @@
         zone: zuul.ansible.com
       when: hostvars[item].node_attributes.public_ipv6
       with_inventory_hostnames:
-        - all
+        - all:!disabled


### PR DESCRIPTION
These hosts won't have node_attributes by default.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>