### PR TITLE
Retire zm02.sjc1.vexxhost.zuul.ansible.com

### DIFF
--- a/ansible/group_vars/gear.yaml
+++ b/ansible/group_vars/gear.yaml
@@ -183,10 +183,6 @@ iptables_allowed_hosts:
     protocol: tcp
     port: 4730
 
-  - address: zm02.sjc1.vexxhost.zuul.ansible.com
-    protocol: tcp
-    port: 4730
-
   - address: zm03.sjc1.vexxhost.zuul.ansible.com
     protocol: tcp
     port: 4730

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -174,7 +174,9 @@ all:
 
     # NOTE(pabelanger): Hosts added to the disabled group will not have
     # playbooks run against them.
-    disabled: {}
+    disabled:
+      hosts:
+        zm03.sjc1.vexxhost.zuul.ansible.com:
 
     # NOTE(pabelanger): We currently only support a single gear host in this
     # group.  This means, the first host listed will only be used by our

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -113,14 +113,6 @@ all:
         public_ipv4: 38.108.68.49
         public_ipv6: 2604:e100:3:0:f816:3eff:fe62:8a51
 
-    zm02.sjc1.vexxhost.zuul.ansible.com:
-      ansible_host: 38.108.68.159
-      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIFfZtSxXmk41qIEms8oum6Hnz2NTiO32+3GlaJVnJ0iy
-      ansible_user: windmill
-      node_attributes:
-        public_ipv4: 38.108.68.159
-        public_ipv6: 2604:e100:3:0:f816:3eff:fea0:60c8
-
     zm03.sjc1.vexxhost.zuul.ansible.com:
       ansible_host: 38.108.68.132
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIHtE8xNk3bjj2eDID/Vtm+CXPO2QM9+LP/mvZ/VWqp4L
@@ -182,9 +174,7 @@ all:
 
     # NOTE(pabelanger): Hosts added to the disabled group will not have
     # playbooks run against them.
-    disabled:
-      hosts:
-        zm02.sjc1.vexxhost.zuul.ansible.com:
+    disabled: {}
 
     # NOTE(pabelanger): We currently only support a single gear host in this
     # group.  This means, the first host listed will only be used by our
@@ -248,7 +238,6 @@ all:
     zuul-merger:
       hosts:
         zm01.sjc1.vexxhost.zuul.ansible.com:
-        zm02.sjc1.vexxhost.zuul.ansible.com:
         zm03.sjc1.vexxhost.zuul.ansible.com:
 
     zuul-scheduler:


### PR DESCRIPTION
Now that zm03 is online, there is no more need to keep zm02 online.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>