### PR TITLE
Disable zm03.sjc1.vexxhost.zuul.ansible.com

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -185,6 +185,7 @@ all:
     disabled:
       hosts:
         zm02.sjc1.vexxhost.zuul.ansible.com:
+        zm03.sjc1.vexxhost.zuul.ansible.com:
 
     # NOTE(pabelanger): We currently only support a single gear host in this
     # group.  This means, the first host listed will only be used by our


### PR DESCRIPTION
We seem to be having issues connecting to github.com, this is causing
zuul-jobs to randomly fail.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>