### PR TITLE
Rebuild zm02.sjc1.vexxhost.ansible.com

### DIFF
--- a/ansible/group_vars/gear.yaml
+++ b/ansible/group_vars/gear.yaml
@@ -183,6 +183,10 @@ iptables_allowed_hosts:
     protocol: tcp
     port: 4730
 
+  - address: zm02.sjc1.vexxhost.zuul.ansible.com
+    protocol: tcp
+    port: 4730
+
   - address: zm03.sjc1.vexxhost.zuul.ansible.com
     protocol: tcp
     port: 4730

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -113,6 +113,14 @@ all:
         public_ipv4: 38.108.68.49
         public_ipv6: 2604:e100:3:0:f816:3eff:fe62:8a51
 
+    zm02.sjc1.vexxhost.zuul.ansible.com:
+      ansible_host: 38.108.68.105
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAII+p13KzTC7ZKwBvmmyJnQpyMt3ppoA4V3ReEOf+uACM
+      ansible_user: windmill
+      node_attributes:
+        public_ipv4: 38.108.68.105
+        public_ipv6: 2604:e100:3:0:f816:3eff:fef3:e030
+
     zm03.sjc1.vexxhost.zuul.ansible.com:
       ansible_host: 38.108.68.132
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIHtE8xNk3bjj2eDID/Vtm+CXPO2QM9+LP/mvZ/VWqp4L
@@ -240,6 +248,7 @@ all:
     zuul-merger:
       hosts:
         zm01.sjc1.vexxhost.zuul.ansible.com:
+        zm02.sjc1.vexxhost.zuul.ansible.com:
         zm03.sjc1.vexxhost.zuul.ansible.com:
 
     zuul-scheduler:


### PR DESCRIPTION
This bring zm02 back online as a fresh rebuild.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>