### PR TITLE
Remove zm03.sjc1.vexxhost.zuul.ansible.com

### DIFF
--- a/ansible/group_vars/gear.yaml
+++ b/ansible/group_vars/gear.yaml
@@ -187,10 +187,6 @@ iptables_allowed_hosts:
     protocol: tcp
     port: 4730
 
-  - address: zm03.sjc1.vexxhost.zuul.ansible.com
-    protocol: tcp
-    port: 4730
-
   # zuul-scheduler
   - address: zs01.sjc1.vexxhost.zuul.ansible.com
     protocol: tcp

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -121,14 +121,6 @@ all:
         public_ipv4: 38.108.68.105
         public_ipv6: 2604:e100:3:0:f816:3eff:fef3:e030
 
-    zm03.sjc1.vexxhost.zuul.ansible.com:
-      ansible_host: 38.108.68.132
-      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIHtE8xNk3bjj2eDID/Vtm+CXPO2QM9+LP/mvZ/VWqp4L
-      ansible_user: windmill
-      node_attributes:
-        public_ipv4: 38.108.68.132
-        public_ipv6: 2604:e100:3:0:f816:3eff:fe00:f625
-
     zs01.sjc1.vexxhost.zuul.ansible.com:
       ansible_host: 38.108.68.61
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAICknumOQvR11O5j2BCACtrgcXxloen//i9GGmENDCp8o
@@ -182,9 +174,7 @@ all:
 
     # NOTE(pabelanger): Hosts added to the disabled group will not have
     # playbooks run against them.
-    disabled:
-      hosts:
-        zm03.sjc1.vexxhost.zuul.ansible.com:
+    disabled: {}
 
     # NOTE(pabelanger): We currently only support a single gear host in this
     # group.  This means, the first host listed will only be used by our
@@ -249,7 +239,6 @@ all:
       hosts:
         zm01.sjc1.vexxhost.zuul.ansible.com:
         zm02.sjc1.vexxhost.zuul.ansible.com:
-        zm03.sjc1.vexxhost.zuul.ansible.com:
 
     zuul-scheduler:
       hosts:


### PR DESCRIPTION
We really didn't need to launch this server, as we had 3 other mergers
to do the work. Given there are some network issues with it, lets delete
it and use zm02 again.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>