### PR TITLE
python-tox 1.4.2 on centos-7 is broken

### DIFF
--- a/nodepool/elements/nodepool-base/install.d/10-packages
+++ b/nodepool/elements/nodepool-base/install.d/10-packages
@@ -27,4 +27,5 @@ YUM=${YUM:-yum}
 if [[ "$DISTRO_NAME" =~ (centos) ]] ; then
     # NOTE(pabelanger): We do this so we don't enable EPEL by default.
     $YUM -y install --enablerepo=epel haveged python-tox python2-pip
+    pip install tox==1.4.3
 fi


### PR DESCRIPTION
Upgrade to 1.4.3 since this is the latest 1.4.x release.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>