### PR TITLE
Pause ubuntu-bionic DIBs

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -102,6 +102,7 @@ diskimages:
       QEMU_IMG_OPTIONS: compat=0.10
 
   - name: ubuntu-bionic
+    pause: true
     elements:
       - ubuntu-minimal
       - growroot


### PR DESCRIPTION
This is related to python2-pip missing from images now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>