### PR TITLE
Bump eos-4.20.10 down a flavor

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -54,7 +54,7 @@ providers:
         max-servers: 8
         labels: &provider_vexxhost_pools_v2_highcpu_1_labels
           - name: eos-4.20.10
-            flavor-name: v1-standard-2
+            flavor-name: v1-standard-1
             cloud-image: vEOS-4.20.10M-20190501
           - name: centos-7-1vcpu
             flavor-name: v2-highcpu-1


### PR DESCRIPTION
This only uses 2vcpu / 1gb of ram.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>