### PR TITLE
Switch to network_cli for vyos cloud-image

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -41,6 +41,7 @@ providers:
         connection-type: network_cli
       - name: vyos-1.1.8-20190407
         config-drive: true
+        connection-type: network_cli
     pools:
       # NOTE(pabelanger): Please contact pabelanger before making changes to
       # this pool, especially increasing max-servers or changing labels. There


### PR DESCRIPTION
This is to prepare for when we can use vyos_* modules from zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>