### PR TITLE
Upgrade to nodepool 3.6.0

### DIFF
--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -33,7 +33,7 @@ nodepool_service_nodepool_launcher_enabled: false
 nodepool_service_nodepool_launcher_manage: false
 nodepool_service_nodepool_launcher_state: stopped
 
-nodepool_pip_version: 3.5.0
+nodepool_pip_version: 3.6.0
 nodepool_pip_virtualenv_python: python3
 nodepool_pip_virtualenv: "/opt/venv/nodepool-{{ nodepool_pip_version }}"
 


### PR DESCRIPTION
This is the latest release which includes fixes for ssh-keyscans for
network_cli connections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>