### PR TITLE
Upgrade diskiamge-builder to 2.22.0

### DIFF
--- a/ansible/group_vars/nodepool-builder.yaml
+++ b/ansible/group_vars/nodepool-builder.yaml
@@ -11,7 +11,7 @@
 # under the License.
 ---
 # windmill.diskimage-builder
-diskimage_builder_pip_version: 2.19.0
+diskimage_builder_pip_version: 2.22.0
 diskimage_builder_pip_virtualenv_python: python3
 diskimage_builder_pip_virtualenv: "{{ nodepool_pip_virtualenv }}"
 


### PR DESCRIPTION
This includes latest fixes for fedora-29 and dbus, as well python3
glean.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>