### PR TITLE
Upgrade nodepool to 3.6.1.dev2

### DIFF
--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -33,7 +33,7 @@ nodepool_service_nodepool_launcher_enabled: false
 nodepool_service_nodepool_launcher_manage: false
 nodepool_service_nodepool_launcher_state: stopped
 
-nodepool_pip_version: 3.6.0
+nodepool_pip_version: 3.6.1.dev2
 nodepool_pip_virtualenv_python: python3
 nodepool_pip_virtualenv: "/opt/venv/nodepool-{{ nodepool_pip_version }}"
 


### PR DESCRIPTION
This development version picks up:

  https://opendev.org/zuul/nodepool/commit/aaf36db8c674c00bcb47697a1e448fdbfe35b461

Allow openstack provider labels to configure networks.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>