### PR TITLE
Use new provider label networks

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -57,12 +57,14 @@ providers:
         max-servers: 8
         networks:
           - Public Internet
-          - Private Network (10.0.0.0/8 only)
-          - Private Network (Floating Public)
         labels: &provider_limestone_pools_s1_small_labels
           - name: eos-4.20.10
             flavor-name: s1.small
             cloud-image: vEOS-4.20.10M-20190501
+            networks:
+              - Public Internet
+              - Private Network (10.0.0.0/8 only)
+              - Private Network (Floating Public)
           - name: centos-7-1vcpu
             flavor-name: s1.small
             diskimage: centos-7
@@ -101,9 +103,7 @@ providers:
       - name: s1.small
         max-servers: 0
         networks:
-          - db5d9d4d-74d9-4dee-998c-389be8bf4739
-          - 11605176-8693-4aff-bd07-9cbddd331797
-          - f25ed0fb-a7d9-4ca9-8ad6-c4ef32b0b551
+          - Public Internet
         labels: *provider_limestone_pools_s1_small_labels
       - name: s1.large
         max-servers: 0

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -50,13 +50,15 @@ providers:
       - name: v2-highcpu-1
         networks: &provider_vexxhost_pools_v2_highcpu_1_networks
           - public
-          - net1
-          - net2
         max-servers: 8
         labels: &provider_vexxhost_pools_v2_highcpu_1_labels
           - name: eos-4.20.10
             flavor-name: v1-standard-2
             cloud-image: vEOS-4.20.10M-20190501
+            networks:
+              - public
+              - net1
+              - net2
           - name: centos-7-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: centos-7
@@ -75,6 +77,10 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
+            networks:
+              - public
+              - net1
+              - net2
       - name: v2-highcpu-4
         max-servers: 2
         labels: &provider_vexxhost_pools_v2_highcpu_4_labels


### PR DESCRIPTION
Only our ansible-network specific network labels, need more then 1
network. Everything else, just needs 1.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>