### PR TITLE
Remove old vexxhost-ansible-network providers

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -21,17 +21,6 @@ labels:
     max-ready-age: 600
 
 providers:
-  - name: vexxhost-ansible-network-mtl1
-    cloud: vexxhost-ansible-network
-    region-name: 'ca-ymq-1'
-    boot-timeout: 120
-    launch-timeout: 300
-    rate: 0.001
-    # NOTE(pabelanger): Strip ansible-network from provider.name to keep
-    # hostname length under 64.
-    hostname-format: '{label.name}-vexxhost-mtl1-{node.id}'
-    diskimages: []
-
   - name: limestone-us-dfw-1
     cloud: limestone
     region-name: us-dfw-1

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -118,17 +118,6 @@ providers:
         max-servers: 2
         labels: *provider_vexxhost_pools_v2_highcpu_4_labels
 
-  - name: vexxhost-ansible-network-sjc1
-    cloud: vexxhost-ansible-network
-    region-name: sjc1
-    boot-timeout: 120
-    launch-timeout: 300
-    rate: 0.001
-    # NOTE(pabelanger): Strip ansible-network from provider.name to keep
-    # hostname length under 64.
-    hostname-format: '{label.name}-vexxhost-sjc1-{node.id}'
-    diskimages: []
-
 diskimages:
   - name: centos-7
   - name: fedora-29


### PR DESCRIPTION
We no longer need this, as everything as been migrated to new nodepool
configuration.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>