### PR TITLE
Remove vexxhost-ansible-network from nodepool-builders

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -38,18 +38,6 @@ providers:
     rate: 0.001
     diskimages: *provider_diskimages
 
-  - name: vexxhost-ansible-network-mtl1
-    cloud: vexxhost-ansible-network
-    region-name: 'ca-ymq-1'
-    rate: 0.001
-    diskimages: []
-
-  - name: vexxhost-ansible-network-sjc1
-    cloud: vexxhost-ansible-network
-    region-name: sjc1
-    rate: 0.001
-    diskimages: []
-
 diskimages:
   - name: centos-7
     elements:


### PR DESCRIPTION
This is a follow commit to stop building images for these providers.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>