### PR TITLE
Also install python-pip for ubuntu

### DIFF
--- a/nodepool/elements/nodepool-base/pkg-map
+++ b/nodepool/elements/nodepool-base/pkg-map
@@ -6,6 +6,9 @@
     },
     "fedora": {
       "tox": "python3-tox python2-pip"
+    },
+    "ubuntu": {
+      "tox": "tox python-pip"
     }
   },
   "default": {


### PR DESCRIPTION
Until we land support to change the default ansible_python_interpreter
in zuul / nodepool, we need python2 support.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>