### PR TITLE
Remove /etc/apt/apt.conf.d/95disable-recommends

### DIFF
--- a/nodepool/elements/nodepool-base/pre-install.d/00-enable-apt-recommends
+++ b/nodepool/elements/nodepool-base/pre-install.d/00-enable-apt-recommends
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=setu setpipefail
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+if [[ "$DISTRO_NAME" =~ (ubuntu) ]] ; then
+    rm -rf /etc/apt/apt.conf.d/95disable-recommends
+fi


### PR DESCRIPTION
We want ubuntu images to use recommends.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>