### PR TITLE
Drop vyos HDD size

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -88,7 +88,7 @@ providers:
             cloud-image: vyos-1.1.8-20190407
             key-name: infra-root-keys
             boot-from-volume: true
-            volume-size: 80
+            volume-size: 40
             networks:
               - public
               - net1


### PR DESCRIPTION
We don't need 80GB for this server, drop to 40GB so we can maybe launch
more.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>