### PR TITLE
Enabled scheduler.relative_priority for zuul

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -28,6 +28,7 @@ start = False
 tenant_config = {{ zuul_file_main_yaml_dest }}
 log_config = /etc/zuul/scheduler-logging.conf
 pidfile = /var/run/zuul-scheduler/zuul-scheduler.pid
+relative_priority = true
 state_dir = {{ zuul_user_home }}
 
 {% endif -%}


### PR DESCRIPTION
This will prevent a single project from consuming all the nodes at once.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>