### PR TITLE
Bring online vsrx3-18.4R1 images in nodepool provider vexxhost

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -27,6 +27,8 @@ labels:
     max-ready-age: 600
   - name: ubuntu-xenial-4vcpu
     max-ready-age: 600
+  - name: vsrx3-18.4R1
+    max-ready-age: 600
   - name: vyos-1.1.8-1vcpu
     max-ready-age: 600
 
@@ -49,6 +51,9 @@ providers:
     cloud-images: &provider_vexxhost_cloud-images
       - name: vEOS-4.20.10M-20190501
         # NOTE(pabelanger): This seems to mess up the boot-loader for eos
+        config-drive: false
+        connection-type: network_cli
+      - name: vsrx3-18.4R1-S2.4-20190514
         config-drive: false
         connection-type: network_cli
       - name: vyos-1.1.8-20190407
@@ -83,6 +88,16 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
+          - name: vsrx3-18.4R1
+            flavor-name: v2-highcpu-1
+            cloud-image: vsrx3-18.4R1-S2.4-20190514
+            key-name: infra-root-keys
+            networks:
+              - public
+              - net1
+              - net2
+            boot-from-volume: true
+            volume-size: 40
           - name: ubuntu-bionic-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: ubuntu-bionic


### PR DESCRIPTION
We'll be using these for network-integration testins against
ansible/ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>