### PR TITLE
Install ansible 2.8.0 on zuul-executors

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -45,6 +45,13 @@ zuul_executor_ansible:
     ansible_pip_virtualenv_python: python3
     ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.7.10
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.7
+  - ansible_pip_name:
+      - ansible==2.8.0
+      - ara
+      - openstacksdk
+    ansible_pip_virtualenv_python: python3
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.8.0
+    ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.8
 
 # openstack.logrotate
 logrotate_configs:


### PR DESCRIPTION
Now that ansible 2.8.0 is released, perpare our zuul-executors for next
version of zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>