### PR TITLE
Disable FIPs for limestone nodepool provider

### DIFF
--- a/nodepool/clouds.yaml.j2
+++ b/nodepool/clouds.yaml.j2
@@ -15,6 +15,7 @@ clouds:
       project_id: {{ __nodepool_clouds_yaml_limestone_project_id }}
       project_domain_id: default
       user_domain_id: default
+    floating_ip_source: None
     regions:
       - us-dfw-1
       - us-slc


### PR DESCRIPTION
There is no need to consume a FIP, limestone has public ipv4 / ipv6 on
its public network.  This avoids the issue of being charged a FIP on the
private network.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>