### PR TITLE
Revert "Disable limestone-us-slc"

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -131,12 +131,12 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: s1.small
-        max-servers: 0
+        max-servers: 8
         networks:
           - Public Internet
         labels: *provider_limestone_pools_s1_small_labels
       - name: s1.large
-        max-servers: 0
+        max-servers: 2
         networks:
           - Public Internet
         labels: *provider_limestone_pools_s1_large_labels


### PR DESCRIPTION
We have a fix in clouds.yaml, lets try using this provider again.

This reverts commit 8fd1228f36d4df88ff6b2f992e095a89fe79372c.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>