### PR TITLE
Double executor.disk_limit_per_job value

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -36,6 +36,7 @@ state_dir = {{ zuul_user_home }}
 {% if inventory_hostname in groups['zuul-executor'] %}
 [executor]
 ansible_root = /var/lib/zuul/venv/ansible
+disk_limit_per_job = 500
 log_config = /etc/zuul/executor-logging.conf
 manage_ansible = false
 private_key_file = {{ zuul_user_home }}/.ssh/nodepool_id_rsa


### PR DESCRIPTION
Now that we are running ansible-test jobs, we need a little more space
for ara-reports.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>