### PR TITLE
Bump up to ansible 2.6.17 and ansible 2.7.11

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -32,18 +32,18 @@ zuul_executor_ansible:
     ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.5.15
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.5
   - ansible_pip_name:
-      - ansible==2.6.16
+      - ansible==2.6.17
       - ara
       - openstacksdk
     ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.6.16
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.6.17
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.6
   - ansible_pip_name:
-      - ansible==2.7.10
+      - ansible==2.7.11
       - ara
       - openstacksdk
     ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.7.10
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.7.11
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.7
   - ansible_pip_name:
       - ansible==2.8.0


### PR DESCRIPTION
These are the latest versions of ansible 2.6 / 2.7, install them on
zuul-executor for jobs to use.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>