### PR TITLE
Add ios-15.6-2T label to nodepool

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -19,6 +19,8 @@ labels:
     max-ready-age: 600
   - name: fedora-29-4vcpu
     max-ready-age: 600
+  - name: ios-15.6-2T
+    max-ready-age: 600
   - name: ubuntu-bionic-1vcpu
     max-ready-age: 600
   - name: ubuntu-bionic-4vcpu
@@ -47,6 +49,9 @@ providers:
       - name: ubuntu-xenial
         config-drive: true
     cloud-images: &provider_limestone_cloud-images
+      - name: ios-15.6-2T-20190524
+        config-drive: false
+        connection-type: network_cli
       - name: vEOS-4.20.10M-20190501
         # NOTE(pabelanger): This seems to mess up the boot-loader for eos
         config-drive: false
@@ -79,6 +84,13 @@ providers:
             flavor-name: s1.small
             diskimage: fedora-29
             key-name: infra-root-keys
+          - name: ios-15.6-2T
+            flavor-name: s1.small
+            cloud-image: ios-15.6-2T-20190524
+            networks:
+              - Public Internet
+              - Private Network (10.0.0.0/8 only)
+              - Private Network (Floating Public)
           - name: ubuntu-bionic-1vcpu
             flavor-name: s1.small
             diskimage: ubuntu-bionic

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -21,6 +21,8 @@ labels:
     max-ready-age: 600
   - name: fedora-29-4vcpu
     max-ready-age: 600
+  - name: ios-15.6-2T
+    max-ready-age: 600
   - name: ubuntu-bionic-1vcpu
     max-ready-age: 600
   - name: ubuntu-bionic-4vcpu
@@ -52,6 +54,9 @@ providers:
         config-drive: true
     cloud-images: &provider_vexxhost_cloud-images
       - name: iosv-20190524
+        config-drive: false
+        connection-type: network_cli
+      - name: ios-15.6-2T-20190524
         config-drive: false
         connection-type: network_cli
       - name: vEOS-4.20.10M-20190501
@@ -100,6 +105,13 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
+          - name: ios-15.6-2T
+            flavor-name: v2-highcpu-1
+            cloud-image: ios-15.6-2T-20190524
+            networks:
+              - public
+              - net1
+              - net2
           - name: vsrx3-18.4R1
             flavor-name: v2-highcpu-2
             cloud-image: vsrx3-18.4R1-S2.4-20190514


### PR DESCRIPTION
This is the replacement label for the current ios images only in
vexxhost. We'll remove them once we update our nodesets in zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>