### PR TITLE
Disable host-key-checking on s1.medium pool

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -58,7 +58,7 @@ providers:
         config-drive: false
         # NOTE(pabelanger): We don't have default gateway setup on boot, so
         # this is an attempt to setup nodepool from doing ssh-keyscan.
-        connection-type: blah
+        connection-type: network_cli
       - name: vEOS-4.20.10M-20190501
         # NOTE(pabelanger): This seems to mess up the boot-loader for eos
         config-drive: false
@@ -98,13 +98,6 @@ providers:
               - Public Internet
               - Private Network (10.0.0.0/8 only)
               - Private Network (Floating Public)
-          - name: iosxrv-6.1.3
-            flavor-name: s1.medium
-            cloud-image: iosxrv-6.1.3-20190604
-            networks:
-              - Public Internet
-              - Private Network (10.0.0.0/8 only)
-              - Private Network (Floating Public)
           - name: ubuntu-bionic-1vcpu
             flavor-name: s1.small
             diskimage: ubuntu-bionic
@@ -117,6 +110,22 @@ providers:
             flavor-name: s1.small
             cloud-image: vyos-1.1.8-20190407
             key-name: infra-root-keys
+            networks:
+              - Public Internet
+              - Private Network (10.0.0.0/8 only)
+              - Private Network (Floating Public)
+      # NOTE(pabelanger): This is not a long term solution, we need to
+      # disable host-key-checking for iosxr, since it doesn't have a default
+      # gateway.
+      - name: s1.medium
+        max-servers: 10
+        host-key-checking: false
+        networks:
+          - Public Internet
+        labels: &provider_limestone_pools_s1_medium_labels
+          - name: iosxrv-6.1.3
+            flavor-name: s1.medium
+            cloud-image: iosxrv-6.1.3-20190604
             networks:
               - Public Internet
               - Private Network (10.0.0.0/8 only)
@@ -161,6 +170,12 @@ providers:
         networks:
           - Public Internet
         labels: *provider_limestone_pools_s1_small_labels
+      - name: s1.medium
+        max-servers: 10
+        host-key-checking: false
+        networks:
+          - Public Internet
+        labels: *provider_limestone_pools_s1_medium_labels
       - name: s1.large
         max-servers: 5
         networks:


### PR DESCRIPTION
This is to workaround a nodepool bug, which hopefully we can fix
upstream soon.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>