### PR TITLE
Don't collect host keys for iosxrv

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -101,6 +101,7 @@ providers:
           - name: iosxrv-6.1.3
             flavor-name: s1.medium
             cloud-image: iosxrv-6.1.3-20190604
+            host-key-checking: false
             networks:
               - Public Internet
               - Private Network (10.0.0.0/8 only)


### PR DESCRIPTION
Because we don't have a default route on our iosxrv images, collecting
SSH host keys won't work. For now, we can just skip doing this, and have
our controller node talk with the node.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>