### PR TITLE
Bump nodepool to 3.6.1.dev16

### DIFF
--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -33,7 +33,7 @@ nodepool_service_nodepool_launcher_enabled: false
 nodepool_service_nodepool_launcher_manage: false
 nodepool_service_nodepool_launcher_state: stopped
 
-nodepool_pip_version: 3.6.1.dev14
+nodepool_pip_version: 3.6.1.dev16
 nodepool_pip_virtualenv_python: python3
 nodepool_pip_virtualenv: "/opt/venv/nodepool-{{ nodepool_pip_version }}"
 


### PR DESCRIPTION
This picks up our per label host-key-checking option, needed for iosxr
nodes.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>