### PR TITLE
Add iosxr nodes to vexxhost

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -21,6 +21,8 @@ labels:
     max-ready-age: 600
   - name: ios-15.6-2T
     max-ready-age: 600
+  - name: iosxr-6.1.3
+    max-ready-age: 600
   - name: ubuntu-bionic-1vcpu
     max-ready-age: 600
   - name: ubuntu-bionic-4vcpu
@@ -52,6 +54,9 @@ providers:
         config-drive: true
     cloud-images: &provider_vexxhost_cloud-images
       - name: ios-15.6-2T-20190524
+        config-drive: false
+        connection-type: network_cli
+      - name: iosxrv-6.1.3-20190604
         config-drive: false
         connection-type: network_cli
       - name: vEOS-4.20.10M-20190501
@@ -100,6 +105,16 @@ providers:
               - public
               - net1
               - net2
+          - name: iosxr-6.1.3
+            flavor-name: v2-highcpu-2
+            cloud-image: iosxrv-6.1.3-20190604
+            host-key-checking: false
+            networks:
+              - public
+              - net1
+              - net2
+            boot-from-volume: true
+            volume-size: 40
           - name: vsrx3-18.4R1
             flavor-name: v2-highcpu-2
             cloud-image: vsrx3-18.4R1-S2.4-20190514


### PR DESCRIPTION
This is different then limestone, they are named correctly now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>