### PR TITLE
Bump zuul-executor ansible to 2.8.1

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -46,11 +46,11 @@ zuul_executor_ansible:
     ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.7.11
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.7
   - ansible_pip_name:
-      - ansible==2.8.0
+      - ansible==2.8.1
       - ara<1.0.0
       - openstacksdk
     ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.8.0
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.8.1
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.8
 
 # openstack.logrotate


### PR DESCRIPTION
This is the latest release of stable-2.8 branch.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>