### PR TITLE
Switch vsrx3 to v2-standard-2 in vexxhost

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -116,7 +116,7 @@ providers:
             boot-from-volume: true
             volume-size: 40
           - name: vsrx3-18.4R1
-            flavor-name: v2-highcpu-2
+            flavor-name: v2-standard-2
             cloud-image: vsrx3-18.4R1-S2.4-20190514
             key-name: infra-root-keys
             networks:


### PR DESCRIPTION
We might not have enough memory on our junos nodes in vexxhost, this
bumps it up to 2vcpu / 8GB RAM.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>