### PR TITLE
Revert "Upgrade nodepool to 3.7.0"

### DIFF
--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -33,7 +33,7 @@ nodepool_service_nodepool_launcher_enabled: false
 nodepool_service_nodepool_launcher_manage: false
 nodepool_service_nodepool_launcher_state: stopped
 
-nodepool_pip_version: 3.7.0
+nodepool_pip_version: 3.6.1.dev16
 nodepool_pip_virtualenv_python: python3
 nodepool_pip_virtualenv: "/opt/venv/nodepool-{{ nodepool_pip_version }}"
 


### PR DESCRIPTION
This seems to break nodepool, roll back until we can figure out why.

This reverts commit 654805dc58598c421b669fe046528e08168ab49e.