### PR TITLE
Upgrade nodepool to 3.7.1.dev3

### DIFF
--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -33,7 +33,7 @@ nodepool_service_nodepool_launcher_enabled: false
 nodepool_service_nodepool_launcher_manage: false
 nodepool_service_nodepool_launcher_state: stopped
 
-nodepool_pip_version: 3.7.0
+nodepool_pip_version: 3.7.1.dev3
 nodepool_pip_virtualenv_python: python3
 nodepool_pip_virtualenv: "/opt/venv/nodepool-{{ nodepool_pip_version }}"
 


### PR DESCRIPTION
This contains a fix to cap openshift python client, which was preventing
nodepool-launcher from starting properly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>