### PR TITLE
Add back public network for iosxr

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -111,6 +111,7 @@ providers:
             networks:
               - Private Network (10.0.0.0/8 only)
               - Private Network (Floating Public)
+              - Public Internet
           - name: ubuntu-bionic-1vcpu
             flavor-name: s1.small
             diskimage: ubuntu-bionic


### PR DESCRIPTION
This is needed to get nodepool-launcher to work properly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>