### PR TITLE
Install paramiko for ansible 2.8 venv

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -49,6 +49,7 @@ zuul_executor_ansible:
       - ansible==2.8.1
       - ara<1.0.0
       - openstacksdk
+      - paramiko
     ansible_pip_virtualenv_python: python3
     ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.8.1
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.8


### PR DESCRIPTION
This is because ansible no longer installs this dependency by default.
However we still have network jobs that require it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>