### PR TITLE
Revert "Install zuul-executor dependencies"

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -17,8 +17,6 @@ zuul_file_zuul_executor_service_config_manage: true
 zuul_file_zuul_executor_service_config_src: zuul/etc/systemd/system/zuul-executor.service.d/override.conf.j2
 zuul_file_zuul_executor_service_manage: true
 
-zuul_pip_name: zuul[zuul_executor]
-
 zuul_service_zuul_executor_enabled: true
 zuul_service_zuul_executor_manage: true
 zuul_service_zuul_executor_state: started

--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -40,8 +40,8 @@ disk_limit_per_job = 1024
 log_config = /etc/zuul/executor-logging.conf
 manage_ansible = false
 private_key_file = {{ zuul_user_home }}/.ssh/nodepool_id_rsa
-trusted_ro_paths = /opt/venv
-untrusted_ro_paths = /opt/venv
+trusted_ro_paths = /opt/venv/zuul-ansible
+untrusted_ro_paths = /opt/venv/zuul-ansible
 workspace_root = {{ zuul_user_home }}/workspace
 
 {% endif -%}


### PR DESCRIPTION
Now that zuul 3.9.0 has been installed, we should no longer need to do
this. ARA will not be properly detected in our zuul-ansible virtualenv.

This reverts commit a00717ba84d72badc9fc2985a3fa476c2f0bda02.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>