### PR TITLE
Drop max-server in sjc1 by 4vcpu

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -190,10 +190,10 @@ providers:
       # Ansible org.
       - name: v2-highcpu-1
         networks: *provider_vexxhost_pools_v2_highcpu_1_networks
-        max-servers: 16
+        max-servers: 12
         labels: *provider_vexxhost_pools_v2_highcpu_1_labels
       - name: v2-highcpu-4
-        max-servers: 4
+        max-servers: 3
         labels: *provider_vexxhost_pools_v2_highcpu_4_labels
 
 diskimages:


### PR DESCRIPTION
We have leaked some volumes, drop our max-servers to avoid getting
NODE_FAILURE.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>