### PR TITLE
Bump junox vsrx to v2-highcpu-4 flavor

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -116,7 +116,7 @@ providers:
             boot-from-volume: true
             volume-size: 40
           - name: vsrx3-18.4R1
-            flavor-name: v2-standard-2
+            flavor-name: v2-highcpu-4
             cloud-image: vsrx3-18.4R1-S2.4-20190514
             key-name: infra-root-keys
             networks:


### PR DESCRIPTION
The theory is we don't have enough cpu on the current image, bump it to
see if that stops random failures.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>