### PR TITLE
Revert "Bump junox vsrx to v2-highcpu-4 flavor"

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -116,7 +116,7 @@ providers:
             boot-from-volume: true
             volume-size: 40
           - name: vsrx3-18.4R1
-            flavor-name: v2-highcpu-4
+            flavor-name: v2-standard-2
             cloud-image: vsrx3-18.4R1-S2.4-20190514
             key-name: infra-root-keys
             networks:


### PR DESCRIPTION
This was a result of a bug in ansible, lets revert to see if we've
properly fixed it.

This reverts commit d67fdd07c91c464c7f19eed6553f5552e408ed40.