### PR TITLE
Remove unused 2nd pool in nodepool

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -137,7 +137,7 @@ providers:
               - Private Network (10.0.0.0/8 only)
               - Private Network (Floating Public)
       - name: s1.large
-        max-servers: 5
+        max-servers: 0
         networks:
           - Public Internet
           - Private Network (10.0.0.0/8 only)
@@ -179,7 +179,7 @@ providers:
           - Private Network (10.0.0.0/8 only)
         labels: *provider_limestone_pools_s1_small_labels
       - name: s1.large
-        max-servers: 5
+        max-servers: 0
         networks:
           - Public Internet
           - Private Network (10.0.0.0/8 only)

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -148,7 +148,7 @@ providers:
               - net1
               - net2
       - name: v2-highcpu-4
-        max-servers: 4
+        max-servers: 0
         labels: &provider_vexxhost_pools_v2_highcpu_4_labels
           - name: centos-7-4vcpu
             flavor-name: v2-highcpu-4
@@ -193,7 +193,7 @@ providers:
         max-servers: 12
         labels: *provider_vexxhost_pools_v2_highcpu_1_labels
       - name: v2-highcpu-4
-        max-servers: 3
+        max-servers: 0
         labels: *provider_vexxhost_pools_v2_highcpu_4_labels
 
 diskimages:


### PR DESCRIPTION
When we first created our nodepool configuration, we created a 2nd pool
with larger capacity. However, up until now, we've never really use it.
There is also issues with this approach, as multinode resources don't
work across pools.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>