### PR TITLE
Bump iosxr-6.1.3 to v2-highcpu-4

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -106,7 +106,7 @@ providers:
               - net1
               - net2
           - name: iosxr-6.1.3
-            flavor-name: v2-highcpu-2
+            flavor-name: v2-highcpu-4
             cloud-image: iosxrv-6.1.3-20190604
             host-key-checking: false
             networks:


### PR DESCRIPTION
We are seeing random failures on iosxr, bump up the resources to see if
that helps.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>