### PR TITLE
Add git-repos DIB element

### DIFF
--- a/nodepool/elements/git-repos/element-deps
+++ b/nodepool/elements/git-repos/element-deps
@@ -1,0 +1,2 @@
+cache-url
+source-repositories

--- a/nodepool/elements/git-repos/source-repository-projects
+++ b/nodepool/elements/git-repos/source-repository-projects
@@ -1,0 +1,1 @@
+ansible git /opt/git/github.com/ansible/ansible https://github.com/ansible/ansible.git *

--- a/nodepool/elements/nodepool-base/element-deps
+++ b/nodepool/elements/nodepool-base/element-deps
@@ -1,2 +1,3 @@
+git-repos
 package-installs
 zuul-worker


### PR DESCRIPTION
This starts the process of caching git repos onto our images. Which
helps cut down on the amount of data we need to xfter from executors to
nodes.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>