### PR TITLE
Revert "Revert "Bump junox vsrx to v2-highcpu-4 flavor""

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -116,7 +116,7 @@ providers:
             boot-from-volume: true
             volume-size: 40
           - name: vsrx3-18.4R1
-            flavor-name: v2-standard-2
+            flavor-name: v2-highcpu-4
             cloud-image: vsrx3-18.4R1-S2.4-20190514
             key-name: infra-root-keys
             networks:


### PR DESCRIPTION
Switch back to v2-highcpu-4 to standardize flavors.

This reverts commit a5f70e0451db5acfeeb55d15f0ea3638fd2d51b8.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>