### PR TITLE
Add python2-dnf to fedora images

### DIFF
--- a/nodepool/elements/nodepool-base/pkg-map
+++ b/nodepool/elements/nodepool-base/pkg-map
@@ -5,7 +5,7 @@
       "tox": ""
     },
     "fedora": {
-      "tox": "python3-tox python2-pip"
+      "tox": "python3-tox python2-dnf python2-pip"
     },
     "ubuntu": {
       "tox": "tox python-pip"


### PR DESCRIPTION
This bootstraps some required ansible dependencies on our fedora images.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>