### PR TITLE
Add CORS header for log proxy

### DIFF
--- a/zuul/etc/nginx/sites-available/logs-ssl.j2
+++ b/zuul/etc/nginx/sites-available/logs-ssl.j2
@@ -11,6 +11,7 @@ server {
   ssl_certificate_key /etc/letsencrypt/live/logs.zuul.ansible.com/privkey.pem;
 
   location / {
+    add_header 'Access-Control-Allow-Origin' '*';
     rewrite ^([^.]*[^/])$ $1/ permanent;
     proxy_pass https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/logs/;
   }


### PR DESCRIPTION
The Zuul build page uses cross-origin async requests in order to
fetch files from the log server.  Adding this header allows that
to happen.  It means that javascript hosted at any domain is
permitted to request resources from the log server.  That is fine
for public, static resources like this.