### PR TITLE
Revert "Add CORS header for log proxy"

### DIFF
--- a/zuul/etc/nginx/sites-available/logs-ssl.j2
+++ b/zuul/etc/nginx/sites-available/logs-ssl.j2
@@ -11,7 +11,6 @@ server {
   ssl_certificate_key /etc/letsencrypt/live/logs.zuul.ansible.com/privkey.pem;
 
   location / {
-    add_header 'Access-Control-Allow-Origin' '*';
     rewrite ^([^.]*[^/])$ $1/ permanent;
     proxy_pass https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/logs/;
   }


### PR DESCRIPTION
This reverts commit 83f48924c306d380e5029184260ffdc1b6712497.

We have now configured the swift container to add the required
CORS header, which means this is now causing a second header to
appear, which is invalid.  Remove this and just let the swift
header through.