### PR TITLE
Add Daniel Mellado to windmill root users

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -36,6 +36,12 @@ _windmill_users:
     key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCuP0CZE8AYnbm8gxecCxKeRw0wHRyryd+FKmNNsdr0d3UvfCbqNzLigrqEBZsKpofi3M4qCWNpKRyfhnjPynLTQjP1vnX9AbL9UGoiHxScfvh3skntTYMs9ezJRd0rMJJZO76FPo8bJLDlwxAQl8m/nuj3HfYiO5hYE7P+a3rhsJh4nEfBb7xh+Q5yM0PWObkkBl6IRiBYjlcsXNZHgTA5kNuihUk5bHqAw54sHh05DhpgOITpTw4LFbh4Ew2NKq49dEb2xbTuAyAr2DHNOGgIwKEZpwtKZEIGEuiLbb4DQRsfivrvyOjnK2NFjQzGyNOHfsOldWHRQwUKUs8nrxKdXvqcrfMnSVaibeYK2TRL+6jd9kc5SIhWI3XLm7HbX7uXMD7/JQrkL25Rcs6nndDCH72DJLz+ynA/T5umMbNBQ9tybL5z73IOpfShRGjQYego22CxDOy7e/5OEMHNoksbFb1S02viM9O2puS7LDqqfT9JIbbPqCrbRi/zOXo0f4EXo6xKUAmd8qlV+6f/p57/qFihzQDaRFVlFEH3k7qwsw7PYGUTwkPaThe6xyZN6D5jqxCZU3aSYu+FGb0oYo+M5IxOm0Cb4NNsvvkRPxWtwSayfFGu6+m/+/RyA3GBcAMev7AuyKN+K2vGMsLagHOx4i+5ZAcUwGzLeXAENNum3w==
     gid: 2001
     uid: 2001
+  dmellado:
+    comment: Daniel Mellado
+    email: dmellado@redhat.com
+    key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvLBCvbloQQwbvlrAEU/txha1cvX0lQ1eGCNddiXfE8u/a+C9IVCs8YxyOV5r2MTC+8GLbMMF4XYgizl1Xtsm0VW4YBtJ1jXo36W+eZZJ8GCwWdjYcyjqFyfHBDA1qLR/G09u45wFDf+ohvUMCwPsCk87T5MuwLLkhD3hFpizkpou2rsop3KOd6d8GBUVQ1z29aOIqE1yrsCKqqD2i8f1eA3uhu0r9Rx22YZWnjx7nZ4PVKZrzH1i6KwPw4aO6Ximd7y9dDXnFVSogpN1gwtL1XgqRfmBH9RiGRWtON/vuvXtw4JoWpy8R6t9tXmNM/SjFkwdNMSaHMGgxtKp+YTXF
+    gid: 2002
+    uid: 2002
 
 windmill_users: "{{ _windmill_users }}"
 


### PR DESCRIPTION
This commit adds dmellado's keys to windmill-root-users group.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>