### PR TITLE
Create limestone2 providers for iosxr nodes

### DIFF
--- a/nodepool/clouds.yaml.j2
+++ b/nodepool/clouds.yaml.j2
@@ -25,6 +25,25 @@ clouds:
             - name: Private Network (10.0.0.0/8 only)
             - name: Private Network (Floating Public)
 
+  limestone2:
+    profile: limestonenetworks
+    auth:
+      password: {{ __nodepool_clouds_yaml_limestone_password }}
+      username: {{ __nodepool_clouds_yaml_limestone_username }}
+      project_id: {{ __nodepool_clouds_yaml_limestone_project_id }}
+      project_domain_id: default
+      user_domain_id: default
+    floating_ip_source: None
+    regions:
+      - name: us-dfw-1
+      - name: us-slc
+        values:
+          networks:
+            - name: Public Internet
+            - name: Private Network (10.0.0.0/8 only)
+              routes_externally: True
+            - name: Private Network (Floating Public)
+
   vexxhost:
     profile: vexxhost
     auth:

--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -62,11 +62,6 @@ providers:
       - name: ios-15.6-2T-20190524
         config-drive: false
         connection-type: network_cli
-      - name: iosxrv-6.1.3-20190604
-        config-drive: false
-        # NOTE(pabelanger): We don't have default gateway setup on boot, so
-        # this is an attempt to setup nodepool from doing ssh-keyscan.
-        connection-type: network_cli
       - name: vEOS-4.20.10M-20190501
         # NOTE(pabelanger): This seems to mess up the boot-loader for eos
         config-drive: false
@@ -83,7 +78,7 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: s1.small
-        max-servers: 20
+        max-servers: 15
         networks:
           - Public Internet
           - Private Network (10.0.0.0/8 only)
@@ -130,13 +125,6 @@ providers:
               - Public Internet
               - Private Network (10.0.0.0/8 only)
               - Private Network (Floating Public)
-          - name: iosxrv-6.1.3
-            flavor-name: s1.medium
-            cloud-image: iosxrv-6.1.3-20190604
-            host-key-checking: false
-            networks:
-              - Private Network (10.0.0.0/8 only)
-              - Private Network (Floating Public)
           - name: ubuntu-bionic-1vcpu
             flavor-name: s1.small
             diskimage: ubuntu-bionic
@@ -176,11 +164,87 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: s1.small
-        max-servers: 20
+        max-servers: 15
         networks:
           - Public Internet
           - Private Network (10.0.0.0/8 only)
         labels: *provider_limestone_pools_s1_small_labels
+
+  - name: limestone2-us-dfw-1
+    cloud: limestone2
+    region-name: us-dfw-1
+    boot-timeout: 300
+    launch-timeout: 300
+    rate: 0.001
+    diskimages: &provider_limestone2_diskimages
+      - name: centos-7
+        config-drive: true
+      - name: fedora-29
+        config-drive: true
+      - name: ubuntu-bionic
+        config-drive: true
+      - name: ubuntu-xenial
+        config-drive: true
+    cloud-images: &provider_limestone2_cloud-images
+      - name: iosxrv-6.1.3-20190604
+        config-drive: false
+        # NOTE(pabelanger): We don't have default gateway setup on boot, so
+        # this is an attempt to setup nodepool from doing ssh-keyscan.
+        connection-type: network_cli
+    pools:
+      # NOTE(pabelanger): Please contact pabelanger before making changes to
+      # this pool, especially increasing max-servers or changing labels. There
+      # is a real world financial cost in doing so that is charged to the
+      # Ansible org.
+      - name: s1.small
+        max-servers: 5
+        networks:
+          - Public Internet
+          - Private Network (10.0.0.0/8 only)
+        labels: &provider_limestone2_pools_s1_small_labels
+          - name: centos-7-1vcpu
+            flavor-name: s1.small
+            diskimage: centos-7
+            key-name: infra-root-keys
+          - name: fedora-29-1vcpu
+            flavor-name: s1.small
+            diskimage: fedora-29
+            key-name: infra-root-keys
+          - name: iosxrv-6.1.3
+            flavor-name: s1.medium
+            cloud-image: iosxrv-6.1.3-20190604
+            host-key-checking: false
+            networks:
+              - Private Network (10.0.0.0/8 only)
+              - Private Network (Floating Public)
+          - name: ubuntu-bionic-1vcpu
+            flavor-name: s1.small
+            diskimage: ubuntu-bionic
+            key-name: infra-root-keys
+          - name: ubuntu-xenial-1vcpu
+            flavor-name: s1.small
+            diskimage: ubuntu-xenial
+            key-name: infra-root-keys
+
+  - name: limestone2-us-slc
+    cloud: limestone2
+    region-name: us-slc
+    boot-timeout: 300
+    launch-timeout: 300
+    rate: 0.001
+    diskimages: *provider_limestone2_diskimages
+    cloud-images: *provider_limestone2_cloud-images
+    pools:
+      # NOTE(pabelanger): Please contact pabelanger before making changes to
+      # this pool, especially increasing max-servers or changing labels. There
+      # is a real world financial cost in doing so that is charged to the
+      # Ansible org.
+      - name: s1.small
+        max-servers: 5
+        networks:
+          - Public Internet
+          - Private Network (10.0.0.0/8 only)
+        labels: *provider_limestone2_pools_s1_small_labels
 
 diskimages:
   - name: centos-7

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -28,6 +28,18 @@ providers:
     rate: 0.001
     diskimages: *provider_diskimages
 
+  - name: limestone2-us-dfw-1
+    cloud: limestone2
+    region-name: us-dfw-1
+    rate: 0.001
+    diskimages: *provider_diskimages
+
+  - name: limestone2-us-slc
+    cloud: limestone2
+    region-name: us-slc
+    rate: 0.001
+    diskimages: *provider_diskimages
+
   - name: vexxhost-ca-ymq-1
     cloud: vexxhost
     region-name: ca-ymq-1


### PR DESCRIPTION
Sadly, this looks to be the only way right now to make iosxr work
properly on limestone. This is mostly because nodepool / openstacksdk
doesn't allow this level of control when dealing with networks.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>