### PR TITLE
Remove iosxr label from nodepool

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -21,8 +21,6 @@ labels:
     max-ready-age: 600
   - name: ios-15.6-2T
     max-ready-age: 600
-  - name: iosxr-6.1.3
-    max-ready-age: 600
   - name: iosxrv-6.1.3
     max-ready-age: 600
   - name: ubuntu-bionic-1vcpu
@@ -116,14 +114,6 @@ providers:
           - name: ios-15.6-2T
             flavor-name: v2-highcpu-1
             cloud-image: ios-15.6-2T-20190524
-            networks:
-              - public
-              - net1
-              - net2
-          - name: iosxr-6.1.3
-            flavor-name: v2-highcpu-8
-            cloud-image: iosxrv-6.1.3-20190604
-            host-key-checking: false
             networks:
               - public
               - net1


### PR DESCRIPTION
Now that iosxrv is working fine, we can remove this one.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>