### PR TITLE
Bump zuul to 3.10.2 for security fix

### DIFF
--- a/ansible/group_vars/zuul.yaml
+++ b/ansible/group_vars/zuul.yaml
@@ -21,7 +21,7 @@ zuul_user_shell: /bin/bash
 zuul_file_main_yaml_src: "{{ project_config_git_dest }}/zuul/tenants.yaml"
 zuul_file_zuul_conf_src: "{{ windmill_config_git_dest }}/zuul/zuul.conf.j2"
 
-zuul_pip_version: 3.10.1
+zuul_pip_version: 3.10.2
 zuul_pip_virtualenv_python: python3
 zuul_pip_virtualenv: "/opt/venv/zuul-{{ zuul_pip_version }}"
 zuul_pip_virtualenv_symlink: /opt/venv/zuul


### PR DESCRIPTION
This deals with a potential exploit with synchronize:

  https://zuul-ci.org/docs/zuul/releasenotes.html#relnotes-3-10-2

Signed-off-by: Paul Belanger <pabelanger@redhat.com>