### PR TITLE
Try building fedora-30 again

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -87,7 +87,6 @@ diskimages:
       QEMU_IMG_OPTIONS: compat=0.10
 
   - name: fedora-30
-    pause: true
     elements:
       - fedora-minimal
       - growroot


### PR DESCRIPTION
We have a new version of diskimage-builder, that should fix our
fedora-30 build issues.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>