### PR TITLE
Use python3 for fedora-30 labels

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -257,5 +257,6 @@ diskimages:
   - name: centos-7
   - name: fedora-29
   - name: fedora-30
+    python-path: /usr/bin/python3
   - name: ubuntu-bionic
   - name: ubuntu-xenial

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -193,5 +193,6 @@ diskimages:
   - name: centos-7
   - name: fedora-29
   - name: fedora-30
+    python-path: /usr/bin/python3
   - name: ubuntu-bionic
   - name: ubuntu-xenial

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -101,6 +101,7 @@ diskimages:
       DIB_RELEASE: '30'
       DIB_SIMPLE_INIT_NETWORKMANAGER: '1'
       QEMU_IMG_OPTIONS: compat=0.10
+    python-path: /usr/bin/python3
 
   - name: ubuntu-bionic
     pause: false


### PR DESCRIPTION
This is because python2 isn't installed by default now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>