### PR TITLE
Add python3-libselinux to fedora images

### DIFF
--- a/nodepool/elements/nodepool-base/pkg-map
+++ b/nodepool/elements/nodepool-base/pkg-map
@@ -5,7 +5,7 @@
       "tox": ""
     },
     "fedora": {
-      "tox": "python3-tox python2-pip"
+      "tox": "python3-tox python2-pip python3-libselinux"
     },
     "ubuntu": {
       "tox": "tox python-pip"


### PR DESCRIPTION
This is needed if we want to use python3 for ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>