### PR TITLE
Disable tmps /tmp on fedora images

### DIFF
--- a/nodepool/elements/nodepool-base/finalise.d/89-fedora-tmpfs
+++ b/nodepool/elements/nodepool-base/finalise.d/89-fedora-tmpfs
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=set setu setpipefail indent
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+if [ ${DISTRO_NAME} = "fedora" ]; then
+    # NOTE(pabelanger): Because we run 1GB size fedora images, it is possible
+    # to have 512mb /tmp, which is too small for our use case.
+    systemctl mask tmp.mount
+fi


### PR DESCRIPTION
We don't want to use tmpfs for /tmp, because we have limited memory on
our 1GB instances.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>