### PR TITLE
Disable limestone / ovh until billing is solved

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -87,7 +87,7 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: s1.small
-        max-servers: 20
+        max-servers: 0
         networks:
           - Public Internet
           - Private Network (10.0.0.0/8 only)
@@ -185,7 +185,7 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: s1.small
-        max-servers: 20
+        max-servers: 0
         networks:
           - Public Internet
           - Private Network (10.0.0.0/8 only)
@@ -214,7 +214,7 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: main
-        max-servers: 5
+        max-servers: 0
         labels: &provider_ovh_pools_main_labels
           - name: centos-7-1vcpu
             flavor-name: s1-4
@@ -250,7 +250,7 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: main
-        max-servers: 5
+        max-servers: 0
         labels: *provider_ovh_pools_main_labels
 
 diskimages:


### PR DESCRIPTION
We've proved that running our testing in new clouds, is just a matter of
getting access to credentials for them, and usually jobs just work.  For
now, disable testing in these regions until we can figure out a testing
strategy.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>