### PR TITLE
Add centos-8 images to nodepool

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -17,6 +17,8 @@ labels:
     max-ready-age: 600
   - name: centos-7-16vcpu
     max-ready-age: 600
+  - name: centos-8-1vcpu
+    max-ready-age: 600
   - name: eos-4.20.10
     max-ready-age: 600
   - name: fedora-29-1vcpu
@@ -53,6 +55,8 @@ providers:
     rate: 0.001
     diskimages: &provider_limestone_diskimages
       - name: centos-7
+        config-drive: true
+      - name: centos-8
         config-drive: true
       - name: fedora-29
         config-drive: true
@@ -114,6 +118,10 @@ providers:
           - name: centos-7-16vcpu
             flavor-name: d1.d1541.0
             diskimage: centos-7
+            key-name: infra-root-keys
+          - name: centos-8-1vcpu
+            flavor-name: s1.small
+            diskimage: centos-8
             key-name: infra-root-keys
           - name: fedora-29-1vcpu
             flavor-name: s1.small
@@ -200,6 +208,8 @@ providers:
     diskimages: &provider_ovh_diskimages
       - name: centos-7
         config-drive: true
+      - name: centos-8
+        config-drive: true
       - name: fedora-29
         config-drive: true
       - name: fedora-30
@@ -219,6 +229,10 @@ providers:
           - name: centos-7-1vcpu
             flavor-name: s1-4
             diskimage: centos-7
+            key-name: infra-root-keys
+          - name: centos-8-1vcpu
+            flavor-name: s1-4
+            diskimage: centos-8
             key-name: infra-root-keys
           - name: fedora-29-1vcpu
             flavor-name: s1-4
@@ -255,6 +269,7 @@ providers:
 
 diskimages:
   - name: centos-7
+  - name: centos-8
   - name: fedora-29
   - name: fedora-30
     python-path: /usr/bin/python3

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -15,6 +15,8 @@ labels:
     max-ready-age: 600
   - name: centos-7-4vcpu
     max-ready-age: 600
+  - name: centos-8-1vcpu
+    max-ready-age: 600
   - name: fedora-29-1vcpu
     max-ready-age: 600
   - name: fedora-29-4vcpu
@@ -47,6 +49,8 @@ providers:
     rate: 0.001
     diskimages: &provider_vexxhost_diskimages
       - name: centos-7
+        config-drive: true
+      - name: centos-8
         config-drive: true
       - name: fedora-29
         config-drive: true
@@ -100,6 +104,12 @@ providers:
           - name: centos-7-4vcpu
             flavor-name: v2-highcpu-4
             diskimage: centos-7
+            key-name: infra-root-keys
+            boot-from-volume: true
+            volume-size: 80
+          - name: centos-8-1vcpu
+            flavor-name: v2-highcpu-1
+            diskimage: centos-8
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
@@ -191,6 +201,7 @@ providers:
 
 diskimages:
   - name: centos-7
+  - name: centos-8
   - name: fedora-29
   - name: fedora-30
     python-path: /usr/bin/python3

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -13,6 +13,8 @@ providers:
     diskimages: &provider_diskimages
       - name: centos-7
         config-drive: true
+      - name: centos-8
+        config-drive: true
       - name: fedora-29
         config-drive: true
       - name: fedora-30
@@ -69,6 +71,24 @@ diskimages:
       DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
       DIB_SIMPLE_INIT_NETWORKMANAGER: '1'
       QEMU_IMG_OPTIONS: compat=0.10
+
+  - name: centos-8
+    elements:
+      - centos-minimal
+      - epel
+      - growroot
+      - nodepool-base
+      - openssh-server
+      - simple-init
+      - vm
+    env-vars:
+      DIB_CHECKSUM: '1'
+      DIB_EPEL_DISABLED: '1'
+      DIB_GRUB_TIMEOUT: '0'
+      DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
+      DIB_SIMPLE_INIT_NETWORKMANAGER: '1'
+      QEMU_IMG_OPTIONS: compat=0.10
+    python-path: /usr/bin/python3
 
   - name: fedora-29
     elements:


### PR DESCRIPTION
Now that diskimage-builder supports centos-8 builds, lets try testing
them out.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>