### PR TITLE
Disable image uploads for ovh / limestone

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -10,6 +10,30 @@ providers:
     cloud: limestone
     region-name: us-dfw-1
     rate: 0.001
+    diskimages: []
+
+  - name: limestone-us-slc
+    cloud: limestone
+    region-name: us-slc
+    rate: 0.001
+    diskimages: []
+
+  - name: ovh-bhs3
+    cloud: ovh
+    region-name: BHS3
+    rate: 0.001
+    diskimages: []
+
+  - name: ovh-uk1
+    cloud: ovh
+    region-name: UK1
+    rate: 0.001
+    diskimages: []
+
+  - name: vexxhost-ca-ymq-1
+    cloud: vexxhost
+    region-name: ca-ymq-1
+    rate: 0.001
     diskimages: &provider_diskimages
       - name: centos-7
         config-drive: true
@@ -23,30 +47,6 @@ providers:
         config-drive: true
       - name: ubuntu-xenial
         config-drive: true
-
-  - name: limestone-us-slc
-    cloud: limestone
-    region-name: us-slc
-    rate: 0.001
-    diskimages: *provider_diskimages
-
-  - name: ovh-bhs3
-    cloud: ovh
-    region-name: BHS3
-    rate: 0.001
-    diskimages: *provider_diskimages
-
-  - name: ovh-uk1
-    cloud: ovh
-    region-name: UK1
-    rate: 0.001
-    diskimages: *provider_diskimages
-
-  - name: vexxhost-ca-ymq-1
-    cloud: vexxhost
-    region-name: ca-ymq-1
-    rate: 0.001
-    diskimages: *provider_diskimages
 
   - name: vexxhost-sjc1
     cloud: vexxhost


### PR DESCRIPTION
This is because these providers are currently disabled, and blocking the
ability for us to upload new images.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>