### PR TITLE
Install tox from pypi for centos-8

### DIFF
--- a/nodepool/elements/nodepool-base/install.d/10-packages
+++ b/nodepool/elements/nodepool-base/install.d/10-packages
@@ -28,4 +28,7 @@ if [ ${DISTRO_NAME} = "centos" -a ${DIB_RELEASE} -lt 8 ]; then
     # NOTE(pabelanger): We do this so we don't enable EPEL by default.
     $YUM -y install --enablerepo=epel haveged python-tox python2-pip
     pip install tox==1.4.3
+elif [ ${DISTRO_NAME} = "centos" -a ${DIB_RELEASE} -gt 7 ]; then
+    # NOTE(pabelanger): There is no tox package for centos-8, pip install it.
+    pip3 install tox
 fi


### PR DESCRIPTION
There currently isn't a tox RPM package for centos-8, install it from
pypi to make our jobs work.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>