### PR TITLE
Add fedora-30 specific pkgmap for nodepool images

### DIFF
--- a/nodepool/elements/nodepool-base/pkg-map
+++ b/nodepool/elements/nodepool-base/pkg-map
@@ -5,6 +5,11 @@
         "ntp": "chrony",
         "ntpdate": ""
        }
+    },
+    "fedora": {
+      "30": {
+        "tox": "python3-tox python3-pip python3-libselinux"
+       }
     }
   },
   "distro": {
@@ -13,7 +18,7 @@
       "tox": ""
     },
     "fedora": {
-      "tox": "python3-tox python2-pip python3-libselinux"
+      "tox": "python3-tox python2-pip python2-libselinux"
     },
     "ubuntu": {
       "tox": "tox python-pip"


### PR DESCRIPTION
This will be the new format moving forward, so we can support difference
python packages for fedroa distros.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>