### PR TITLE
Add ansible 2.9.1 to zuul-executors

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -51,6 +51,14 @@ zuul_executor_ansible:
     ansible_pip_virtualenv_python: python3
     ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.8.5
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.8
+  - ansible_pip_name:
+      - ansible==2.9.1
+      - ara<1.0.0
+      - openstacksdk
+      - paramiko
+    ansible_pip_virtualenv_python: python3
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.9.1
+    ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.9
 
 # openstack.logrotate
 logrotate_configs:


### PR DESCRIPTION
Now that 2.9.1 is released, we can start to prepare for zuul to be
uploaded to use it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>