### PR TITLE
Update vcsa to use python3

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -75,6 +75,7 @@ providers:
         connection-type: network_cli
       - name: VMware-VCSA-all-6.7.0-14836122
         config-drive: true
+        python-path: /usr/bin/python3
       - name: vsrx3-18.4R1-S2.4-20190514
         config-drive: false
         connection-type: network_cli


### PR DESCRIPTION
There is no python2 for vcenter.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>