### PR TITLE
esxi-6.7.0: preserve the hostname

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -130,6 +130,10 @@ providers:
           - name: esxi-6.7.0
             flavor-name: s1.medium
             cloud-image: esxi-6.7.0-20190802001-STANDARD
+            userdata: |
+              #cloud-config
+              hostname: vcenter.test
+              fqdn: vcenter.test
           - name: fedora-29-1vcpu
             flavor-name: s1.small
             diskimage: fedora-29


### PR DESCRIPTION
VCSA exposes the internal service using URL prefixed by `https://${hostname}`.
Each service also validate the hostname using the SSL certificate.

If we break the hostname, a couple of services won't start.