### PR TITLE
Set python-path for esxi image

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -81,6 +81,7 @@ providers:
         connection-type: network_cli
       - name: esxi-6.7.0-20190802001-STANDARD
         config-drive: true
+        python-path: /usr/bin/python3
     pools:
       # NOTE(pabelanger): Please contact pabelanger before making changes to
       # this pool, especially increasing max-servers or changing labels. There


### PR DESCRIPTION
We need to use python3 for vmware esxi.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>