### PR TITLE
Set image_format for rdocloud

### DIFF
--- a/nodepool/clouds.yaml.j2
+++ b/nodepool/clouds.yaml.j2
@@ -47,6 +47,7 @@ clouds:
       user_domain_id: default
     regions:
       - RegionOne
+    image_format: raw
 
   vexxhost:
     profile: vexxhost


### PR DESCRIPTION
We need to use raw format, not qcow2.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>