### PR TITLE
Upgrade to ansible 2.9.2 for zuul-executors

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -52,12 +52,12 @@ zuul_executor_ansible:
     ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.8.7
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.8
   - ansible_pip_name:
-      - ansible==2.9.1
+      - ansible==2.9.2
       - ara<1.0.0
       - openstacksdk
       - paramiko
     ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.9.1
+    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.9.2
     ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.9
 
 # openstack.logrotate


### PR DESCRIPTION
This is the latest stable-2.9 release.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>