### PR TITLE
Remove centos-7-16vcpu label

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -15,8 +15,6 @@ labels:
     max-ready-age: 600
   - name: centos-7-8vcpu
     max-ready-age: 600
-  - name: centos-7-16vcpu
-    max-ready-age: 600
   - name: centos-8-1vcpu
     max-ready-age: 600
   - name: eos-4.20.10
@@ -110,10 +108,6 @@ providers:
             key-name: infra-root-keys
           - name: centos-7-8vcpu
             flavor-name: s1.xlarge
-            diskimage: centos-7
-            key-name: infra-root-keys
-          - name: centos-7-16vcpu
-            flavor-name: d1.d1541.0
             diskimage: centos-7
             key-name: infra-root-keys
           - name: centos-8-1vcpu


### PR DESCRIPTION
This is no longer needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>