### PR TITLE
Upgrade zuul to 3.13.0

### DIFF
--- a/ansible/group_vars/zuul.yaml
+++ b/ansible/group_vars/zuul.yaml
@@ -21,7 +21,7 @@ zuul_user_shell: /bin/bash
 zuul_file_main_yaml_src: "{{ project_config_git_dest }}/zuul/tenants.yaml"
 zuul_file_zuul_conf_src: "{{ windmill_config_git_dest }}/zuul/zuul.conf.j2"
 
-zuul_pip_version: 3.11.1
+zuul_pip_version: 3.13.0
 zuul_pip_virtualenv_python: python3
 zuul_pip_virtualenv: "/opt/venv/zuul-{{ zuul_pip_version }}"
 zuul_pip_virtualenv_symlink: /opt/venv/zuul


### PR DESCRIPTION
This is the first release where we support ansible 2.9 for running of
jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>