### PR TITLE
ISO cache: update the images

### DIFF
--- a/nodepool/elements/cache-files/source-repository-images
+++ b/nodepool/elements/cache-files/source-repository-images
@@ -1,2 +1,2 @@
-CentOS-8-x86_64-1905-dvd1.iso file /opt/cache/files/CentOS-8-x86_64-1905-dvd1.iso http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-dvd1.iso
-Fedora-Workstation-Live-x86_64-30-1.2.iso file /opt/cache/files/Fedora-Workstation-Live-x86_64-30-1.2.iso https://download.fedoraproject.org/pub/fedora/linux/releases/30/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-30-1.2.iso
+CentOS-8-x86_64-1905-boot.iso file /opt/cache/files/CentOS-8-x86_64-1905-boot.iso http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-boot.iso
+Fedora-Workstation-Live-x86_64-31-1.9.iso file /opt/cache/files/Fedora-Workstation-Live-x86_64-31-1.9.iso https://download.fedoraproject.org/pub/fedora/linux/releases/31/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-31-1.9.iso


### PR DESCRIPTION
- use CentOS-8 net boot image (=~7GB smaller)
- Use Fedora-31 image