### PR TITLE
Stop managing ansible 2.5 for zuul-executor

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -23,13 +23,6 @@ zuul_service_zuul_executor_state: started
 
 zuul_executor_ansible:
   - ansible_pip_name:
-      - ansible==2.5.15
-      - ara<1.0.0
-      - openstacksdk
-    ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.5.15
-    ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.5
-  - ansible_pip_name:
       - ansible==2.6.20
       - ara<1.0.0
       - openstacksdk


### PR DESCRIPTION
Zuul has now officially dropped support for it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>