### PR TITLE
vcsa: increase the memory from 8GB to 16GB

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -166,7 +166,7 @@ providers:
               - Private Network (10.0.0.0/8 only)
               - Private Network (Floating Public)
           - name: vmware-vcsa-6.7.0
-            flavor-name: s1.large
+            flavor-name: r1.medium
             cloud-image: VMware-VCSA-all-6.7.0-14836122
             key-name: infra-root-keys
 


### PR DESCRIPTION
The 8GB limit is really low, and tends to create side effect. e.g:
https://github.com/ansible/ansible/pull/66378#issuecomment-573672712

Locally, I had to bump from 8GB to 12GB to avoid any any unexpected errors.