### PR TITLE
Stop caching centos-8 image

### DIFF
--- a/nodepool/elements/cache-files/source-repository-images
+++ b/nodepool/elements/cache-files/source-repository-images
@@ -1,2 +1,1 @@
-CentOS-8-x86_64-1905-boot.iso file /opt/cache/files/CentOS-8-x86_64-1905-boot.iso http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-boot.iso
 Fedora-Workstation-Live-x86_64-31-1.9.iso file /opt/cache/files/Fedora-Workstation-Live-x86_64-31-1.9.iso https://download.fedoraproject.org/pub/fedora/linux/releases/31/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-31-1.9.iso


### PR DESCRIPTION
This file is dead upstream down, we can add it back however right now I
need to get image builds working to fix centos-8.1 release problems.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>