### PR TITLE
Add 06-record-builddate script

### DIFF
--- a/nodepool/elements/nodepool-base/install.d/06-record-builddate
+++ b/nodepool/elements/nodepool-base/install.d/06-record-builddate
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# Put a timestamp in the image file of the date the image was built.
+# This is echoed into the logs on each run for easy cross-reference
+
+date --utc "+%Y-%m-%d %H:%M" > /etc/dib-builddate.txt


### PR DESCRIPTION
This will allow us to better track when an image was build at job
runtime.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>