### PR TITLE
Upgrade nodepool / diskimage-builder to latest version

### DIFF
--- a/ansible/group_vars/nodepool-builder.yaml
+++ b/ansible/group_vars/nodepool-builder.yaml
@@ -11,7 +11,7 @@
 # under the License.
 ---
 # windmill.diskimage-builder
-diskimage_builder_pip_version: 2.28.0
+diskimage_builder_pip_version: 2.33.0
 diskimage_builder_pip_virtualenv_python: python3
 diskimage_builder_pip_virtualenv: "{{ nodepool_pip_virtualenv }}"
 

--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -38,7 +38,7 @@ nodepool_service_nodepool_launcher_enabled: false
 nodepool_service_nodepool_launcher_manage: false
 nodepool_service_nodepool_launcher_state: stopped
 
-nodepool_pip_version: 3.10.0
+nodepool_pip_version: 3.11.0
 nodepool_pip_virtualenv_python: python3
 nodepool_pip_virtualenv: "/opt/venv/nodepool-{{ nodepool_pip_version }}"
 


### PR DESCRIPTION
These are the latest versions of each, and includes a centos-8.1 fix we
have applied manually.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>