### PR TITLE
Cap paramiko==2.6.0 for zuul-scheduler

### DIFF
--- a/ansible/group_vars/zuul-scheduler.yaml
+++ b/ansible/group_vars/zuul-scheduler.yaml
@@ -17,7 +17,10 @@ zuul_file_scheduler_logging_conf_manage: true
 
 zuul_file_zuul_scheduler_service_manage: true
 
-zuul_pip_name: zuul[mysql_reporter]
+zuul_pip_name:
+  - zuul[mysql_reporter]
+  # NOTE(pabelanger): Cap paramiko until we can update our gerrit key for opendev.org.
+  - paramiko==2.6.0
 
 zuul_service_zuul_scheduler_enabled: true
 zuul_service_zuul_scheduler_manage: true


### PR DESCRIPTION
This is because, the current gerrit key we use doesn't work with newer
versions of paramiko. We need to fix this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>