### PR TITLE
Add vqfx image to limestone

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -35,6 +35,8 @@ labels:
     max-ready-age: 600
   - name: ubuntu-xenial-4vcpu
     max-ready-age: 600
+  - name: vqfx-18.1R3
+    max-ready-age: 600
   - name: vsrx3-18.4R1
     max-ready-age: 600
   - name: vyos-1.1.8-1vcpu
@@ -73,6 +75,8 @@ providers:
         # NOTE(pabelanger): This seems to mess up the boot-loader for eos
         config-drive: false
         connection-type: network_cli
+      - name: vqfx-18.1R3-S2.5-20200116
+        config-drive: false
       - name: vsrx3-18.4R1-S2.4-20190514
         config-drive: false
         connection-type: network_cli
@@ -149,6 +153,14 @@ providers:
             flavor-name: s1.small
             diskimage: ubuntu-xenial
             key-name: infra-root-keys
+          - name: vqfx-18.1R3
+            flavor-name: s1.tiny
+            cloud-image: vqfx-18.1R3-S2.5-20200116
+            key-name: infra-root-keys
+            networks:
+              - Public Internet
+              - Private Network (10.0.0.0/8 only)
+              - Private Network (Floating Public)
           - name: vsrx3-18.4R1
             flavor-name: s1.medium
             cloud-image: vsrx3-18.4R1-S2.4-20190514


### PR DESCRIPTION
This commit adds vqfx 18.1R3 image to limestone as a cloud provideri for
ansible zuul's nodepool.