### PR TITLE
Remove fedora-30 only workaround for nodepool images

### DIFF
--- a/nodepool/elements/nodepool-base/pkg-map
+++ b/nodepool/elements/nodepool-base/pkg-map
@@ -5,11 +5,6 @@
         "ntp": "chrony",
         "ntpdate": ""
        }
-    },
-    "fedora": {
-      "30": {
-        "tox": "python3-tox python3-pip python3-libselinux"
-       }
     }
   },
   "distro": {
@@ -18,7 +13,7 @@
       "tox": ""
     },
     "fedora": {
-      "tox": "python3-tox python2-pip python2-libselinux"
+      "tox": "python3-tox python3-pip python3-libselinux"
     },
     "ubuntu": {
       "tox": "tox python-pip"


### PR DESCRIPTION
Now that fedora30+ is all we builds, we can update defaults for pkg-map.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>