### PR TITLE
add a CentOS8 flavor with 8GB of memory

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -17,6 +17,8 @@ labels:
     max-ready-age: 600
   - name: centos-8-1vcpu
     max-ready-age: 600
+  - name: centos-8-8vcpu-8gb
+    max-ready-age: 600
   - name: fedora-30-1vcpu
     max-ready-age: 600
   - name: fedora-31-1vcpu
@@ -158,6 +160,12 @@ providers:
             volume-size: 80
           - name: centos-8-1vcpu
             flavor-name: v2-highcpu-1
+            diskimage: centos-8
+            key-name: infra-root-keys
+            boot-from-volume: true
+            volume-size: 80
+          - name: centos-8-8vcpu-8gb
+            flavor-name: v2-highcpu-8
             diskimage: centos-8
             key-name: infra-root-keys
             boot-from-volume: true


### PR DESCRIPTION
We need a machine with 4GB+ to build the ESXi images.