### PR TITLE
Cap virtualenv<2.0.0 for centos-8

### DIFF
--- a/nodepool/elements/nodepool-base/install.d/10-packages
+++ b/nodepool/elements/nodepool-base/install.d/10-packages
@@ -30,5 +30,7 @@ if [ ${DISTRO_NAME} = "centos" -a ${DIB_RELEASE} -lt 8 ]; then
     pip install tox==1.4.3
 elif [ ${DISTRO_NAME} = "centos" -a ${DIB_RELEASE} -gt 7 ]; then
     # NOTE(pabelanger): There is no tox package for centos-8, pip install it.
-    pip3 install tox
+    # NOTE(pabelanger): Cap virtualenv<20.0.0 due to
+    # ERROR:root:ImportError: cannot import name 'ensure_text'
+    pip3 install tox "virtualenv<20.0.0"
 fi


### PR DESCRIPTION
We should figure out where to get tox from on centos-8, because pulling
directly from pypi can lead to things breaking.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>