### PR TITLE
Remove vmware-vcsa-6.7.0 from nl02

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -39,8 +39,6 @@ labels:
     max-ready-age: 600
   - name: ubuntu-xenial-4vcpu
     max-ready-age: 600
-  - name: vmware-vcsa-6.7.0
-    max-ready-age: 600
   - name: vqfx-18.1R3
     max-ready-age: 600
   - name: vsrx3-18.4R1
@@ -119,9 +117,6 @@ providers:
         # NOTE(pabelanger): This seems to mess up the boot-loader for eos
         config-drive: false
         connection-type: network_cli
-      - name: VMware-VCSA-all-6.7.0-14836122-20200204
-        config-drive: true
-        python-path: /usr/bin/python3
       - name: vqfx-18.1R3-S2.5-20200116
         config-drive: false
         connection-type: network_cli
@@ -222,12 +217,6 @@ providers:
           - name: ubuntu-xenial-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: ubuntu-xenial
-            key-name: infra-root-keys
-            boot-from-volume: true
-            volume-size: 80
-          - name: vmware-vcsa-6.7.0
-            flavor-name: v2-highcpu-8
-            cloud-image: VMware-VCSA-all-6.7.0-14836122
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80


### PR DESCRIPTION
Until we have vexxhost setup to use vmware-vcsa-6.7.0, remove it. As
this was stopping the asa node from coming online properly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>