### PR TITLE
Remove bastion02 from bastion group

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -149,7 +149,6 @@ all:
     bastion:
       hosts:
         bastion01.sjc1.vexxhost.zuul.ansible.com:
-        bastion02.ca-ymq-1.vexxhost.zuul.ansible.com:
 
     borg:
       children:


### PR DESCRIPTION
This is because it isn't safe to run two at the same time.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>