### PR TITLE
Stop using tox venv for dns-promote job

### DIFF
--- a/tests/playbooks/windmill-config-dns-promote/run.yaml
+++ b/tests/playbooks/windmill-config-dns-promote/run.yaml
@@ -3,27 +3,16 @@
 
 - hosts: bastion
   tasks:
-    - name: Ensure tox is installed
-      become: true
-      package:
-        name: tox
-        state: present
-
     - name: Create tmp directory for logs
       register: tmp_logs
       tempfile:
         state: directory
 
     - block:
-        - name: Bootstrap tox environment
-          args:
-            chdir: ~/src/github.com/ansible-network/windmill-config
-          shell: tox -v -evenv --notest
-
         - name: Promote DNS in route53
           args:
             chdir: ~/src/github.com/ansible-network/windmill-config
-          shell: .tox/venv/bin/ansible-playbook -v tests/playbooks/windmill-config-dns-promote/route53.yaml
+          shell: /opt/venv/ansible/bin/ansible-playbook -v tests/playbooks/windmill-config-dns-promote/route53.yaml
 
       always:
         - name: Generate static HTML for ARA results


### PR DESCRIPTION
Signed-off-by: Paul Belanger <pabelanger@redhat.com>