### PR TITLE
Remove borg01.ca-ymq-1.vexxhost.zuul.ansible.com from inventory

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -165,8 +165,7 @@ all:
         zuul-scheduler: {}
 
     borg-server:
-      hosts:
-        borg01.ca-ymq-1.vexxhost.zuul.ansible.com:
+      hosts: {}
 
     # NOTE(pabelanger): We currently only support a single database host in
     # this group.  This means, the first host listed will only be used by our


### PR DESCRIPTION
We need to rebuild this server, to ensure the uid / gid are the same as
other servers.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>