### PR TITLE
Add dmellado to all servers

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -52,6 +52,7 @@ _windmill_users:
 windmill_users: "{{ _windmill_users }}"
 
 _windmill_root_users_base:
+  - dmellado
   - pabelanger
   - windmill
 _windmill_root_users_extra: []

--- a/ansible/group_vars/nodepool.yaml
+++ b/ansible/group_vars/nodepool.yaml
@@ -10,11 +10,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 ---
-# TODO(pabelanger): Until we rebuild borg01 and bastion01, just add dmellado
-# to nodepool group
-_windmill_root_users_extra:
-  - dmellado
-
 # windmill.nodepool
 nodepool_user_shell: /bin/bash
 

--- a/ansible/group_vars/zuul.yaml
+++ b/ansible/group_vars/zuul.yaml
@@ -10,11 +10,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 ---
-# TODO(pabelanger): Until we rebuild borg01 and bastion01, just add dmellado
-# to zuul group
-_windmill_root_users_extra:
-  - dmellado
-
 # windmill.zuul
 zuul_user_shell: /bin/bash
 


### PR DESCRIPTION
Now that we have rebuilt bastion02, and disabled borg01, we can add
dmellado as windmill root.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>