### PR TITLE
add vmware-vcsa-7.0.0 flavor

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -47,6 +47,8 @@ labels:
     max-ready-age: 600
   - name: vmware-vcsa-6.7.0
     max-ready-age: 600
+  - name: vmware-vcsa-7.0.0
+    max-ready-age: 600
 
 providers:
   - name: limestone-us-dfw-1
@@ -201,6 +203,10 @@ providers:
           - name: vmware-vcsa-6.7.0
             flavor-name: s1.large
             cloud-image: VMware-VCSA-all-6.7.0-14836122-20200204
+            key-name: infra-root-keys
+          - name: vmware-vcsa-7.0.0
+            flavor-name: s1.xlarge
+            cloud-image: VMware-VCSA-all-7.0.0-15525994-20200324
             key-name: infra-root-keys
 
   - name: limestone-us-slc


### PR DESCRIPTION
The image needs 12GB of memory, and so I use s1.xlarge (16GB).