### PR TITLE
adjust the flavor of esxi-6.7.0_exp

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -185,7 +185,7 @@ providers:
             volume-size: 80
           - name: esxi-6.7.0_exp
             # flavor-name: s1.medium
-            flavor-name: v2-standard-N-iops
+            flavor-name: v2-standard-1-iops
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200206
           - name: fedora-30-1vcpu
             flavor-name: v2-highcpu-1


### PR DESCRIPTION
The `N` in `v2-standard-N-iops` was a variable... :-).