### PR TITLE
define label esxi-6.7.0_exp

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -49,6 +49,8 @@ labels:
     max-ready-age: 600
   - name: vmware-vcsa-7.0.0
     max-ready-age: 600
+  - name: esxi-6.7.0_exp
+    max-ready-age: 600
 
 providers:
   - name: rdocloud-regionone


### PR DESCRIPTION
This to address the following problem on `nl02`:
```
Traceback (most recent call last):
  File "/opt/venv/nodepool-3.12.0/lib/python3.6/site-packages/nodepool/launcher.py", line 1102, in run
    self.updateConfig()
  File "/opt/venv/nodepool-3.12.0/lib/python3.6/site-packages/nodepool/launcher.py", line 962, in updateConfig
    config = self.loadConfig()
  File "/opt/venv/nodepool-3.12.0/lib/python3.6/site-packages/nodepool/launcher.py", line 925, in loadConfig
    config = nodepool_config.loadConfig(self.configfile)
  File "/opt/venv/nodepool-3.12.0/lib/python3.6/site-packages/nodepool/config.py", line 264, in loadConfig
    newconfig.setProviders(config.get('providers'))
  File "/opt/venv/nodepool-3.12.0/lib/python3.6/site-packages/nodepool/config.py", line 150, in setProviders
    p.load(self)
  File "/opt/venv/nodepool-3.12.0/lib/python3.6/site-packages/nodepool/driver/openstack/config.py", line 347, in load
    pp.load(pool, config, self)
  File "/opt/venv/nodepool-3.12.0/lib/python3.6/site-packages/nodepool/driver/openstack/config.py", line 219, in load
    top_label = full_config.labels[pl.name]
KeyError: 'esxi-6.7.0_exp'
```