### PR TITLE
vmware-vcsa-7.0.0-vexxhost-sjc1: boot-from-volume: true

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -268,6 +268,8 @@ providers:
             flavor-name: v2-standard-4
             cloud-image: VMware-VCSA-all-7.0.0-15525994-20200327
             key-name: infra-root-keys
+            boot-from-volume: true
+            volume-size: 40
 
   - name: vexxhost-sjc1
     cloud: vexxhost


### PR DESCRIPTION
True on `boot-from-volume` to avoid the following exeption:

```
Client Error for url: https://compute-sjc1.vexxhost.us/v2.1/servers, Only volume-backed servers are allowed for flavors with zero disk.
```