### PR TITLE
vmware-vcsa-6.7.0: boot-from-volume=true

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -264,6 +264,8 @@ providers:
             flavor-name: v2-standard-4
             cloud-image: VMware-VCSA-all-6.7.0-14836122-20200204
             key-name: infra-root-keys
+            boot-from-volume: true
+            volume-size: 40
           - name: vmware-vcsa-7.0.0
             flavor-name: v2-standard-4
             cloud-image: VMware-VCSA-all-7.0.0-15525994-20200327


### PR DESCRIPTION
On sjc1 we need `boot-from-volume=true` if flavor come with 0 disk. It's the case of `v2-standard-4`.