### PR TITLE
split esxi-6.7.0 in two flavors

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -23,6 +23,10 @@ labels:
     max-ready-age: 600
   - name: esxi-6.7.0
     max-ready-age: 600
+  - name: esxi-6.7.0-with-nested
+    max-ready-age: 600
+  - name: esxi-6.7.0-without-nested
+    max-ready-age: 600
   - name: fedora-30-1vcpu
     max-ready-age: 600
   - name: fedora-31-1vcpu
@@ -145,8 +149,13 @@ providers:
             diskimage: centos-8
             key-name: infra-root-keys
           - name: esxi-6.7.0
-            # flavor-name: s1.medium
             flavor-name: c1.hwetest.1
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200206
+          - name: esxi-6.7.0-with-nested
+            flavor-name: c1.hwetest.1
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200206
+          - name: esxi-6.7.0-without-nested
+            flavor-name: s1.medium
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200206
           - name: fedora-30-1vcpu
             flavor-name: s1.small

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -19,6 +19,8 @@ labels:
     max-ready-age: 600
   - name: centos-8-1vcpu
     max-ready-age: 600
+  - name: esxi-6.7.0-without-nested
+    max-ready-age: 600
   - name: fedora-30-1vcpu
     max-ready-age: 600
   - name: fedora-31-1vcpu
@@ -48,8 +50,6 @@ labels:
   - name: vmware-vcsa-6.7.0
     max-ready-age: 600
   - name: vmware-vcsa-7.0.0
-    max-ready-age: 600
-  - name: esxi-6.7.0_exp
     max-ready-age: 600
 
 providers:
@@ -185,9 +185,8 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
-          - name: esxi-6.7.0_exp
-            # flavor-name: s1.medium
-            flavor-name: v2-standard-1-iops
+          - name: esxi-6.7.0-without-nested
+            flavor-name: v2-highcpu-4
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200206
           - name: fedora-30-1vcpu
             flavor-name: v2-highcpu-1


### PR DESCRIPTION
Create two new ESXi flavors:

- `esxi-6.7.0_without_nested`: this ESXi instance cannot run nested VM (no
  vmx/svm flags)
- `esxi-6.7.0_with_nested`: can run a nested VM, currently only c1.hwetest.1
  on us-dfw-1

We keep the `esxi-6.7.0` flavor to simplify the transition to the new
model. `esxi-6.7.0_exp` is dropped, we don't need it anymore.