### PR TITLE
vmware: e1000 drive broken on vexxhost's v2-highcpu-4

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -186,7 +186,7 @@ providers:
             boot-from-volume: true
             volume-size: 80
           - name: esxi-6.7.0-without-nested
-            flavor-name: v2-highcpu-4
+            flavor-name: v2-standard-1-iops
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200206
           - name: fedora-30-1vcpu
             flavor-name: v2-highcpu-1


### PR DESCRIPTION
Use `v2-standard-1-iops` to ensure we don't use CentOS7/RDO computes.