### PR TITLE
drop the esxi-6.7.0 label

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -21,8 +21,6 @@ labels:
     max-ready-age: 600
   - name: eos-4.20.10
     max-ready-age: 600
-  - name: esxi-6.7.0
-    max-ready-age: 600
   - name: esxi-6.7.0-with-nested
     max-ready-age: 600
   - name: esxi-6.7.0-without-nested
@@ -148,9 +146,6 @@ providers:
             flavor-name: s1.small
             diskimage: centos-8
             key-name: infra-root-keys
-          - name: esxi-6.7.0
-            flavor-name: c1.hwetest.1
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200206
           - name: esxi-6.7.0-with-nested
             flavor-name: c1.hwetest.1
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200206


### PR DESCRIPTION
It has been superseded by:
- `esxi-6.7.0-with-nested`
- `esxi-6.7.0-without-nested`