### PR TITLE
Enable auto purge of zookeeper snapshots

### DIFF
--- a/zookeeper/etc/zookeeper/conf/zoo.cfg
+++ b/zookeeper/etc/zookeeper/conf/zoo.cfg
@@ -23,6 +23,10 @@ clientPort=2181
 server.{{ loop.index }}={{ hostvars[host].ansible_host | ipwrap }}:2888:3888
 {% endfor %}
 
+# The time interval in hours for which the purge task has to be triggered. Set
+# to a positive integer (1 and above) to enable the auto purging.
+autopurge.purgeInterval=6
+
 # To avoid seeks ZooKeeper allocates space in the transaction log file in
 # blocks of preAllocSize kilobytes. The default block size is 64M. One reason
 # for changing the size of the blocks is to reduce the block size if snapshots


### PR DESCRIPTION
We filled the HDD of zk01, because of old snapshots.  By default
zookeeper doesn't purge data, so lets enable it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>