### PR TITLE
Enable AWS images in us-east-2

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -13,7 +13,11 @@ labels:
     max-ready-age: 600
   - name: centos-7-1vcpu
     max-ready-age: 600
+  - name: centos-7-1vcpu-aws
+    max-ready-age: 600
   - name: centos-7-4vcpu
+    max-ready-age: 600
+  - name: centos-7-4vcpu-aws
     max-ready-age: 600
   - name: centos-7-8vcpu
     max-ready-age: 600
@@ -28,6 +32,8 @@ labels:
   - name: fedora-30-1vcpu
     max-ready-age: 600
   - name: fedora-31-1vcpu
+    max-ready-age: 600
+  - name: fedora-31-1vcpu-aws
     max-ready-age: 600
   - name: ios-15.6-2T
     max-ready-age: 600
@@ -64,6 +70,14 @@ providers:
       - name: ubuntu-bionic
         image-id: ami-07c1207a9d40bc3bd
         username: ubuntu
+      - name: centos-7
+        # aws ec2 describe-images --region us-east-2 --owners aws-marketplace --filters Name=product-code,Values=aw0evgkw8e5c1q413zgy5pjce| jq -r '.Images|sort_by(.CreationDate)[-1].ImageId'
+        image-id: ami-01e36b7901e884a10
+        username: centos
+      - name: fedora-31
+        # aws ec2 describe-images --region us-east-2 --owners 125523088429 --filters 'Name=name,Values=Fedora-Cloud-Base-31*' 'Name=image-type,Values=machine' 'Name=architecture,Values=x86_64'| jq -r '.Images|sort_by(.CreationDate)[-1].ImageId'
+        image-id: ami-0a7b53d11c7a9b9e4
+        username: fedora
     pools:
       - name: main
         max-servers: 5
@@ -74,7 +88,18 @@ providers:
             cloud-image: ubuntu-bionic
             instance-type: t2.small
             key-name: zuul
-
+          - name: centos-7-1vcpu-aws
+            cloud-image: centos-7
+            instance-type: t2.small
+            key-name: zuul
+          - name: centos-7-4vcpu-aws
+            cloud-image: centos-7
+            instance-type: t2.small
+            key-name: zuul
+          - name: fedora-31-1vcpu-aws
+            cloud-image: fedora-31
+            instance-type: t2.small
+            key-name: zuul
   - name: limestone-us-dfw-1
     cloud: limestone
     region-name: us-dfw-1


### PR DESCRIPTION
We provide the following labels:

- `centos-7-1vcpu-aws`
- `centos-7-4vcpu-aws`
- `fedora-31-vcpu-aws`

The `centos-7` images come from AWS. We will adjust that later when `nodepool`
will be able to upload DIB images.