### PR TITLE
Bump vexxhost max-servers to 20

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -153,7 +153,7 @@ providers:
         networks: &provider_vexxhost_pools_v2_highcpu_1_networks
           - public
           - net1
-        max-servers: 16
+        max-servers: 20
         labels: &provider_vexxhost_pools_v2_highcpu_1_labels
           - name: asav9-12-3
             flavor-name: v1-standard-2
@@ -292,7 +292,7 @@ providers:
       # Ansible org.
       - name: v2-highcpu-1
         networks: *provider_vexxhost_pools_v2_highcpu_1_networks
-        max-servers: 16
+        max-servers: 20
         labels: *provider_vexxhost_pools_v2_highcpu_1_labels
 
 diskimages:


### PR DESCRIPTION
Lets slowly up the capacity in vexxhost, to help reduce backlog.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>