### PR TITLE
Use BFV for nxos labels in limestone

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -234,6 +234,8 @@ providers:
               - Public Internet
               - Private Network (10.0.0.0/8 only)
               - Private Network (Floating Public)
+            boot-from-volume: true
+            volume-size: 150
           - name: ubuntu-bionic-1vcpu
             flavor-name: s1.small
             diskimage: ubuntu-bionic
@@ -361,6 +363,8 @@ providers:
               - Public Internet
               - Private Network (10.0.0.0/8 only)
               - Private Network (Floating Public)
+            boot-from-volume: true
+            volume-size: 150
           - name: ubuntu-bionic-1vcpu
             flavor-name: s1.small
             diskimage: ubuntu-bionic


### PR DESCRIPTION
The root disk image needed is too small.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>