### PR TITLE
aws: transition to 172.16/16 subnet

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -91,7 +91,9 @@ providers:
     pools:
       - name: main
         max-servers: 5
-        subnet-id: subnet-0eb42065e8c196f38
+        # This subnet comes with 172.16/16 CIDR. This is a requirement for
+        # the QRadar image.
+        subnet-id: subnet-049b1e99211b42502
         security-group-id: sg-0dea0b7beee7f8b88
         labels:
           - name: ubuntu-bionic-1vcpu-aws


### PR DESCRIPTION
We need a 172.16/16 subnet for the QRadar image.