### PR TITLE
aws/centos8: enable EPEL first to avoid race

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -93,6 +93,7 @@ providers:
               #cloud-config
               package_update: true
               packages:
+                - git
                 - virtualenv
                 - tox
                 - unbound
@@ -115,15 +116,13 @@ providers:
             userdata: |
               #cloud-config
               package_update: true
-              packages:
-                - python3-virtualenv
-                - unbound
-              packages:
-                - python3-virtualenv
-                - unbound
-              runcmd:
+              bootcmd:
                 - dnf install -y epel-release
-                - dnf install -y python3-tox
+              packages:
+                - git
+                - python3-virtualenv
+                - unbound
+                - python3-tox
               users:
                 - name: zuul
                   gecos: Zuul user


### PR DESCRIPTION
If we enable EPEL in `runcmd`, Zuul can run a job in parallel and
expect `tox` be here to early.