### PR TITLE
vexxhost: use a pool for the ESXi

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -187,12 +187,6 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
-          - name: esxi-6.7.0-without-nested
-            flavor-name: v2-standard-1-iops
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
-          - name: esxi-6.7.0-with-nested
-            flavor-name: v2-standard-1-iops
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
           - name: fedora-30-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: fedora-30
@@ -276,6 +270,19 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 55
+      - name: esxi-pool
+        networks: *provider_vexxhost_pools_v2_highcpu_1_networks
+        max-servers: 10
+        labels:
+          - name: esxi-6.7.0-without-nested
+            flavor-name: v2-highcpu-4
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            boot-from-volume: true
+            volume-size: 2
+          - name: esxi-6.7.0-with-nested
+            flavor-name: v2-standard-1-iops
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+
 
   - name: vexxhost-sjc1
     cloud: vexxhost
@@ -294,6 +301,15 @@ providers:
         networks: *provider_vexxhost_pools_v2_highcpu_1_networks
         max-servers: 40
         labels: *provider_vexxhost_pools_v2_highcpu_1_labels
+      - name: esxi-pool
+        networks: *provider_vexxhost_pools_v2_highcpu_1_networks
+        max-servers: 10
+        labels:
+          - name: esxi-6.7.0-without-nested
+            flavor-name: v2-highcpu-4
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            boot-from-volume: true
+            volume-size: 2
 
 diskimages:
   - name: centos-7


### PR DESCRIPTION
The ESXi configuration is now the same between the two Vexxhost zone.
`v2-standard-1-iops` is not available in `sjc1`, and if nodepool retries
to spawn a node there, we get a `node_failure`.

So, it's impossible use the same pool configuration properly. We now
have a pool dedicated to the ESXi nodes.