### PR TITLE
esxi: Ensure the volume is large enough.

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -329,7 +329,7 @@ providers:
           - name: esxi-6.7.0-without-nested
             flavor-name: v2-highcpu-4
             boot-from-volume: true
-            volume-size: 2
+            volume-size: 5
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
           - name: fedora-30-1vcpu
             flavor-name: v2-highcpu-1


### PR DESCRIPTION
This change address the following error:

Size of specified image 4GB is larger than volume size 2GB.