### PR TITLE
esxi: ensure fqdn < 63 characters

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -213,7 +213,7 @@ providers:
       - name: vyos-1.1.8-20190407
         config-drive: true
         connection-type: network_cli
-      - name: esxi-6.7.0-20190802001-STANDARD-20200606
+      - name: esxi-6.7.0-20190802001-STANDARD-20200630
         config-drive: true
         python-path: /usr/bin/python3
       - name: VMware-VCSA-all-6.7.0-14836122-20200530
@@ -265,10 +265,18 @@ providers:
             key-name: infra-root-keys
           - name: esxi-6.7.0-with-nested-unstable
             flavor-name: c1.hwetest.1
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200630
+            userdata: |
+              #cloud-config
+              hostname: esxi.test
+              fqdn: esxi.test
           - name: esxi-6.7.0-without-nested
             flavor-name: l1.medium
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200630
+            userdata: |
+              #cloud-config
+              hostname: esxi.test
+              fqdn: esxi.test
           - name: fedora-30-1vcpu
             flavor-name: l1.small
             diskimage: fedora-30
@@ -393,10 +401,18 @@ providers:
             key-name: infra-root-keys
           - name: esxi-6.7.0-with-nested-unstable
             flavor-name: s1.medium
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200630
+            userdata: |
+              #cloud-config
+              hostname: esxi.test
+              fqdn: esxi.test
           - name: esxi-6.7.0-without-nested
             flavor-name: s1.medium
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200630
+            userdata: |
+              #cloud-config
+              hostname: esxi.test
+              fqdn: esxi.test
           - name: fedora-30-1vcpu
             flavor-name: s1.small
             diskimage: fedora-30

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -134,7 +134,7 @@ providers:
       - name: vyos-1.1.8-20190407
         config-drive: true
         connection-type: network_cli
-      - name: esxi-6.7.0-20190802001-STANDARD-20200606
+      - name: esxi-6.7.0-20190802001-STANDARD-20200630
         config-drive: true
         python-path: /usr/bin/python3
       - name: VMware-VCSA-all-6.7.0-14836122-20200530
@@ -189,10 +189,18 @@ providers:
             volume-size: 80
           - name: esxi-6.7.0-without-nested
             flavor-name: v2-standard-1-iops
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200630
+            userdata: |
+              #cloud-config
+              hostname: esxi.test
+              fqdn: esxi.test
           - name: esxi-6.7.0-with-nested
             flavor-name: v2-standard-1-iops
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200630
+            userdata: |
+              #cloud-config
+              hostname: esxi.test
+              fqdn: esxi.test
           - name: fedora-30-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: fedora-30
@@ -330,7 +338,11 @@ providers:
             flavor-name: v2-highcpu-4
             boot-from-volume: true
             volume-size: 5
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200606
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200630
+            userdata: |
+              #cloud-config
+              hostname: esxi.test
+              fqdn: esxi.test
           - name: fedora-30-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: fedora-30


### PR DESCRIPTION
ESXi FQDN cannot go above 63 characters. By default, the FQDN on
Vexxhost go above this limit. As a result, the FQDN and hostnames
collected by Ansible or `excfg` are actually truncated. This breaks
the name resolution on the hosts.

We don't have the same problem with Limestone, but I prefect to apply
the configuration anyway, this to be consistent.