### PR TITLE
Remove fedora-30 support

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -29,8 +29,6 @@ labels:
     max-ready-age: 600
   - name: esxi-6.7.0-without-nested
     max-ready-age: 600
-  - name: fedora-30-1vcpu
-    max-ready-age: 600
   - name: fedora-31-1vcpu
     max-ready-age: 600
   - name: ios-15.6-2T
@@ -177,8 +175,6 @@ providers:
         config-drive: true
       - name: centos-8
         config-drive: true
-      - name: fedora-30
-        config-drive: true
       - name: fedora-31
         config-drive: true
       - name: ubuntu-bionic
@@ -277,10 +273,6 @@ providers:
               #cloud-config
               hostname: esxi.test
               fqdn: esxi.test
-          - name: fedora-30-1vcpu
-            flavor-name: l1.small
-            diskimage: fedora-30
-            key-name: infra-root-keys
           - name: fedora-31-1vcpu
             flavor-name: l1.small
             diskimage: fedora-31
@@ -413,10 +405,6 @@ providers:
               #cloud-config
               hostname: esxi.test
               fqdn: esxi.test
-          - name: fedora-30-1vcpu
-            flavor-name: s1.small
-            diskimage: fedora-30
-            key-name: infra-root-keys
           - name: fedora-31-1vcpu
             flavor-name: s1.small
             diskimage: fedora-31
@@ -489,8 +477,6 @@ providers:
 diskimages:
   - name: centos-7
   - name: centos-8
-  - name: fedora-30
-    python-path: /usr/bin/python3
   - name: fedora-31
     python-path: /usr/bin/python3
   - name: ubuntu-bionic

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -23,8 +23,6 @@ labels:
     max-ready-age: 600
   - name: esxi-6.7.0-with-nested
     max-ready-age: 600
-  - name: fedora-30-1vcpu
-    max-ready-age: 600
   - name: fedora-31-1vcpu
     max-ready-age: 600
   - name: ios-15.6-2T
@@ -102,8 +100,6 @@ providers:
       - name: centos-7
         config-drive: true
       - name: centos-8
-        config-drive: true
-      - name: fedora-30
         config-drive: true
       - name: fedora-31
         config-drive: true
@@ -201,12 +197,6 @@ providers:
               #cloud-config
               hostname: esxi.test
               fqdn: esxi.test
-          - name: fedora-30-1vcpu
-            flavor-name: v2-highcpu-1
-            diskimage: fedora-30
-            key-name: infra-root-keys
-            boot-from-volume: true
-            volume-size: 80
           - name: fedora-31-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: fedora-31
@@ -343,12 +333,6 @@ providers:
               #cloud-config
               hostname: esxi.test
               fqdn: esxi.test
-          - name: fedora-30-1vcpu
-            flavor-name: v2-highcpu-1
-            diskimage: fedora-30
-            key-name: infra-root-keys
-            boot-from-volume: true
-            volume-size: 80
           - name: fedora-31-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: fedora-31
@@ -431,7 +415,6 @@ providers:
 diskimages:
   - name: centos-7
   - name: centos-8
-  - name: fedora-30
     python-path: /usr/bin/python3
   - name: fedora-31
     python-path: /usr/bin/python3

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -15,8 +15,6 @@ providers:
         config-drive: true
       - name: centos-8
         config-drive: true
-      - name: fedora-30
-        config-drive: true
       - name: fedora-31
         config-drive: true
       - name: fedora-32
@@ -95,23 +93,6 @@ diskimages:
       DIB_GRUB_TIMEOUT: '0'
       DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
       DIB_RELEASE: '8'
-      DIB_SIMPLE_INIT_NETWORKMANAGER: '1'
-      QEMU_IMG_OPTIONS: compat=0.10
-    python-path: /usr/bin/python3
-
-  - name: fedora-30
-    elements:
-      - fedora-minimal
-      - growroot
-      - nodepool-base
-      - openssh-server
-      - simple-init
-      - vm
-    env-vars:
-      DIB_CHECKSUM: '1'
-      DIB_GRUB_TIMEOUT: '0'
-      DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
-      DIB_RELEASE: '30'
       DIB_SIMPLE_INIT_NETWORKMANAGER: '1'
       QEMU_IMG_OPTIONS: compat=0.10
     python-path: /usr/bin/python3


### PR DESCRIPTION
This image is EOL, all jobs should be migrated to fedora-31.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>