### PR TITLE
esxi: bump image version

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -213,7 +213,7 @@ providers:
       - name: vyos-1.1.8-20190407
         config-drive: true
         connection-type: network_cli
-      - name: esxi-6.7.0-20190802001-STANDARD-20200713
+      - name: esxi-6.7.0-20190802001-STANDARD-20200713-2
         config-drive: true
         python-path: /usr/bin/python3
       - name: VMware-VCSA-all-6.7.0-14836122-20200530
@@ -265,14 +265,14 @@ providers:
             key-name: infra-root-keys
           - name: esxi-6.7.0-with-nested-unstable
             flavor-name: c1.hwetest.1
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
               hostname: esxi.test
               fqdn: esxi.test
           - name: esxi-6.7.0-without-nested
             flavor-name: l1.medium
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
               hostname: esxi.test
@@ -401,14 +401,14 @@ providers:
             key-name: infra-root-keys
           - name: esxi-6.7.0-with-nested-unstable
             flavor-name: s1.medium
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
               hostname: esxi.test
               fqdn: esxi.test
           - name: esxi-6.7.0-without-nested
             flavor-name: s1.medium
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
               hostname: esxi.test

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -134,7 +134,7 @@ providers:
       - name: vyos-1.1.8-20190407
         config-drive: true
         connection-type: network_cli
-      - name: esxi-6.7.0-20190802001-STANDARD-20200713
+      - name: esxi-6.7.0-20190802001-STANDARD-20200713-2
         config-drive: true
         python-path: /usr/bin/python3
       - name: VMware-VCSA-all-6.7.0-14836122-20200530
@@ -189,14 +189,14 @@ providers:
             volume-size: 80
           - name: esxi-6.7.0-without-nested
             flavor-name: v2-standard-1-iops
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
               hostname: esxi.test
               fqdn: esxi.test
           - name: esxi-6.7.0-with-nested
             flavor-name: v2-standard-1-iops
-            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713
+            cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
               hostname: esxi.test


### PR DESCRIPTION
Bump to `esxi-6.7.0-20190802001-STANDARD-20200713-2` to get current
version of esxi-cloud-init.py:

https://github.com/goneri/esxi-cloud-init/commit/1baebcf9a432df907d7125c916ee87d1835ccddb