### PR TITLE
rdocloud: drop rdocloud-regionone definition

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -42,12 +42,6 @@ providers:
     rate: 0.001
     diskimages: []
 
-  - name: rdocloud-regionone
-    cloud: rdocloud
-    region-name: regionOne
-    rate: 0.001
-    diskimages: *provider_diskimages
-
   - name: vexxhost-ca-ymq-1
     cloud: vexxhost
     region-name: ca-ymq-1


### PR DESCRIPTION
Drop a last reference to RDOCloud.