### PR TITLE
turns scheduler.relative_priority on

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -30,6 +30,7 @@ log_config = /etc/zuul/scheduler-logging.conf
 pidfile = /var/run/zuul-scheduler/zuul-scheduler.pid
 relative_priority = true
 state_dir = {{ zuul_user_home }}
+relative_priority = True
 
 {% endif -%}
 


### PR DESCRIPTION
This should be enough to avoid the situation where a job get stuck for
hours, just because another pipeline drains all the resources.