### PR TITLE
esxi: call the host esxi1.test by default

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -268,15 +268,15 @@ providers:
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
-              hostname: esxi.test
-              fqdn: esxi.test
+              hostname: esxi1.test
+              fqdn: esxi1.test
           - name: esxi-6.7.0-without-nested
             flavor-name: l1.medium
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
-              hostname: esxi.test
-              fqdn: esxi.test
+              hostname: esxi1.test
+              fqdn: esxi1.test
           - name: fedora-31-1vcpu
             flavor-name: l1.small
             diskimage: fedora-31
@@ -404,15 +404,15 @@ providers:
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
-              hostname: esxi.test
-              fqdn: esxi.test
+              hostname: esxi1.test
+              fqdn: esxi1.test
           - name: esxi-6.7.0-without-nested
             flavor-name: s1.medium
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
-              hostname: esxi.test
-              fqdn: esxi.test
+              hostname: esxi1.test
+              fqdn: esxi1.test
           - name: fedora-31-1vcpu
             flavor-name: s1.small
             diskimage: fedora-31

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -153,15 +153,15 @@ providers:
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
-              hostname: esxi.test
-              fqdn: esxi.test
+              hostname: esxi1.test
+              fqdn: esxi1.test
           - name: esxi-6.7.0-with-nested
             flavor-name: v2-standard-1-iops
             cloud-image: esxi-6.7.0-20190802001-STANDARD-20200713-2
             userdata: |
               #cloud-config
-              hostname: esxi.test
-              fqdn: esxi.test
+              hostname: esxi1.test
+              fqdn: esxi1.test
           - name: fedora-31-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: fedora-31


### PR DESCRIPTION
During the host configuration with run the following command to set
up the hostname: `esxcli system hostname set --fqdn=esxi1.test`.
It often fails with:
`IO error: [Errno 97] Address family not supported by protocol`.
By starting with the correct hostname, we will avoid the problematical
command.