### PR TITLE
Upgrade to zuul 3.19.1

### DIFF
--- a/ansible/group_vars/zuul.yaml
+++ b/ansible/group_vars/zuul.yaml
@@ -16,7 +16,7 @@ zuul_user_shell: /bin/bash
 zuul_file_main_yaml_src: "{{ project_config_git_dest }}/zuul/tenants.yaml"
 zuul_file_zuul_conf_src: "{{ windmill_config_git_dest }}/zuul/zuul.conf.j2"
 
-zuul_pip_version: 3.19.0
+zuul_pip_version: 3.19.1
 zuul_pip_virtualenv_python: python3
 zuul_pip_virtualenv: "/opt/venv/zuul-{{ zuul_pip_version }}"
 zuul_pip_virtualenv_symlink: /opt/venv/zuul


### PR DESCRIPTION
Latest release to fix github api issue and security issue on
zuul-executor for untrusted playbook.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>