### PR TITLE
bump VMware-VCSA-all-6.7.0 image

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -216,7 +216,7 @@ providers:
       - name: esxi-6.7.0-20190802001-STANDARD-20200713-2
         config-drive: true
         python-path: /usr/bin/python3
-      - name: VMware-VCSA-all-6.7.0-14836122-20200530
+      - name: VMware-VCSA-all-6.7.0-14836122-20200729
         config-drive: true
         python-path: /usr/bin/python3
       - name: VMware-VCSA-all-7.0.0-16189094-20200529
@@ -343,7 +343,7 @@ providers:
               - Private Network (Floating Public)
           - name: vmware-vcsa-6.7.0
             flavor-name: s1.xlarge
-            cloud-image: VMware-VCSA-all-6.7.0-14836122-20200530
+            cloud-image: VMware-VCSA-all-6.7.0-14836122-20200729
             key-name: infra-root-keys
           - name: vmware-vcsa-7.0.0
             flavor-name: s1.xlarge
@@ -479,7 +479,7 @@ providers:
               - Private Network (Floating Public)
           - name: vmware-vcsa-6.7.0
             flavor-name: s1.xlarge
-            cloud-image: VMware-VCSA-all-6.7.0-14836122-20200530
+            cloud-image: VMware-VCSA-all-6.7.0-14836122-20200729
             key-name: infra-root-keys
           - name: vmware-vcsa-7.0.0
             flavor-name: s1.xlarge

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -98,7 +98,7 @@ providers:
       - name: esxi-6.7.0-20190802001-STANDARD-20200713-2
         config-drive: true
         python-path: /usr/bin/python3
-      - name: VMware-VCSA-all-6.7.0-14836122-20200530
+      - name: VMware-VCSA-all-6.7.0-14836122-20200729
         config-drive: true
         python-path: /usr/bin/python3
       - name: VMware-VCSA-all-7.0.0-16189094-20200529
@@ -235,7 +235,7 @@ providers:
               - net2
           - name: vmware-vcsa-6.7.0
             flavor-name: v2-standard-4
-            cloud-image: VMware-VCSA-all-6.7.0-14836122-20200530
+            cloud-image: VMware-VCSA-all-6.7.0-14836122-20200729
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 40
@@ -368,7 +368,7 @@ providers:
               - net2
           - name: vmware-vcsa-6.7.0
             flavor-name: v2-standard-4
-            cloud-image: VMware-VCSA-all-6.7.0-14836122-20200530
+            cloud-image: VMware-VCSA-all-6.7.0-14836122-20200729
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 40


### PR DESCRIPTION
Bump to 20200729. Image built with:
https://github.com/virt-lightning/vcsa_to_qcow2/commit/cf9963bcf8eec45c00eca4d22ea17b488ed10536