### PR TITLE
bump VMware-VCSA-all-7.0.0-16189094 image

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -219,7 +219,7 @@ providers:
       - name: VMware-VCSA-all-6.7.0-14836122-20200729
         config-drive: true
         python-path: /usr/bin/python3
-      - name: VMware-VCSA-all-7.0.0-16189094-20200529
+      - name: VMware-VCSA-all-7.0.0-16189094-20200730
         config-drive: true
         python-path: /usr/bin/python3
     pools:
@@ -347,7 +347,7 @@ providers:
             key-name: infra-root-keys
           - name: vmware-vcsa-7.0.0
             flavor-name: s1.xlarge
-            cloud-image: VMware-VCSA-all-7.0.0-16189094-20200529
+            cloud-image: VMware-VCSA-all-7.0.0-16189094-20200730
             key-name: infra-root-keys
 
   - name: limestone-us-slc
@@ -483,7 +483,7 @@ providers:
             key-name: infra-root-keys
           - name: vmware-vcsa-7.0.0
             flavor-name: s1.xlarge
-            cloud-image: VMware-VCSA-all-7.0.0-16189094-20200529
+            cloud-image: VMware-VCSA-all-7.0.0-16189094-20200730
             key-name: infra-root-keys
 
 diskimages:

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -101,7 +101,7 @@ providers:
       - name: VMware-VCSA-all-6.7.0-14836122-20200729
         config-drive: true
         python-path: /usr/bin/python3
-      - name: VMware-VCSA-all-7.0.0-16189094-20200529
+      - name: VMware-VCSA-all-7.0.0-16189094-20200730
         config-drive: true
         python-path: /usr/bin/python3
 
@@ -241,7 +241,7 @@ providers:
             volume-size: 40
           - name: vmware-vcsa-7.0.0
             flavor-name: v2-standard-4
-            cloud-image: VMware-VCSA-all-7.0.0-16189094-20200529
+            cloud-image: VMware-VCSA-all-7.0.0-16189094-20200730
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 55
@@ -374,7 +374,7 @@ providers:
             volume-size: 40
           - name: vmware-vcsa-7.0.0
             flavor-name: v2-standard-4
-            cloud-image: VMware-VCSA-all-7.0.0-16189094-20200529
+            cloud-image: VMware-VCSA-all-7.0.0-16189094-20200730
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 55


### PR DESCRIPTION
Bump to `VMware-VCSA-all-7.0.0-16189094-20200730`.
Image build this version of `vcsa_to_qcow2`: https://github.com/virt-lightning/vcsa_to_qcow2/commit/cf9963bcf8eec45c00eca4d22ea17b488ed10536