### PR TITLE
Add smtp connection for zuul-scheduler

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -77,6 +77,12 @@ driver = sql
 dburi = mysql+pymysql://{{ __zuul_zuul_conf_connection_mysql_username_and_password }}@{{ hostvars[groups['database'][0]].ansible_host }}/zuul
 {% endif %}
 
+{% if inventory_hostname in groups['zuul-scheduler'] %}
+[connection smtp]
+driver = smtp
+
+{% endif -%}
+
 [connection github.com]
 driver = github
 app_id = {{ __zuul_conf_connection_github_app_id }}


### PR DESCRIPTION
This is to allow zuul to sent emails when jobs are successful or
failure.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>