### PR TITLE
Revert "disable vexxhost-ca-ymq-1"

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -114,7 +114,7 @@ providers:
         networks: &provider_vexxhost_pools_v2_highcpu_1_networks
           - public
           - net1
-        max-servers: 0
+        max-servers: 40
         labels:
           - name: asav9-12-3
             flavor-name: v1-standard-2


### PR DESCRIPTION
The leaked volumes have been deleted.

This reverts commit 30f3014b10266b29cd77b7ca302e72374e17ce37.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>