### PR TITLE
AWS: fix a typo in fedora-32 metadata

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -90,7 +90,7 @@ providers:
             userdata: |
               #cloud-config
               package_update: true
-              udackages:
+              packages:
                 - git
                 - python3-virtualenv
                 - unbound


### PR DESCRIPTION
`udackages` -> `packages`... Thanks @GomathiselviS :-).