### PR TITLE
move AWS's fedora-32 out of the fedora-32 label

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -63,8 +63,6 @@ providers:
     driver: aws
     region-name: us-east-2
     cloud-images:
-      - name: fedora-32
-        image-id: ami-0677b95262b16499f
       - name: ubuntu-bionic
         image-id: ami-07c1207a9d40bc3bd
       - name: centos-8
@@ -82,32 +80,6 @@ providers:
         subnet-id: subnet-049b1e99211b42502
         security-group-id: sg-0bc8090db4886b59f
         labels:
-          - name: fedora-32-1vcpu
-            cloud-image: fedora-32
-            instance-type: t2.small
-            volume-size: 80
-            key-name: zuul
-            userdata: |
-              #cloud-config
-              package_update: true
-              packages:
-                - git
-                - python3-virtualenv
-                - unbound
-              users:
-                - name: zuul
-                  gecos: Zuul user
-                  primary_group: zuul
-                  groups: adm, wheel, systemd-journal
-                  lock_passwd: true
-                  ssh_authorized_keys:
-                    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDI3XA0A84nUpCr9mfkrDjBdoNFtYMXqXMm2+WsGrOJUA2ESodUDDfTKmsA/xEygdCnj8JfSC3SYhc0uKHVe0RdG20mzntUqD50kB0STFeOHh3ee7FXmMxcLqLlyY9pJkn1V5WOi/D1Lbz8MwRUVBfqufryavwHla/9CPuAtPcut8mTUB0+Rapnv8W3n4dA6PqHNW1tylJUXj6P4trJPnFrdfMaIxc21tfd/QrMM4h90phW3zNILE0qF9UHpQxP0zew/LcD9rc+IhnbgC3DeCQDyiqJOsJRDo58RuwWmQHCF0SfiFQJ4qwrc6TFSJqSdi2aRY0S/vRMbXkD+6Hg2KWQyz6Z6EpY7RARletqJwNnzuuhXr2HSCj5QALe+0U/aUEX+dnydYBX6Nqa+0Rz/qV5aUk4YP1C2/dBCAdbYXPotBT6QBfekE428mJV8Mr7G/M7kwZ8v9WjytyJ8/FYNuekYDWonk6QTwDgQhMTiQI3Yxnu3ID63BL959lfUIv96bsifVI6/D36KTAdFi/dl7Omn5MZ9A5JXA7l+yEJKf4pcPTpQcPbjGSKyaPu0uffEjV9CTr3+VMwzq1uenxGDQ9cT/ud4pEEjwU/ihr6yttouTCvDu9ydrflHljUXxf+X00NW7HkrHnvS43AGnxQzi9g2lTOC9yDlDGbQjmnVjec7w== zuul-executor
-                  sudo: ALL=(ALL) NOPASSWD:ALL
-              runcmd:
-                - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
-                - python3 -m pip install --upgrade pip
-                - python3 -m pip install --upgrade tox
-
           - name: ubuntu-bionic-1vcpu-aws
             cloud-image: ubuntu-bionic
             instance-type: t2.small


### PR DESCRIPTION
We've got a problem with this image because the `git` installation
is slow enough to create a race condition.