### PR TITLE
aws: remove centos-8 temporarily

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -65,9 +65,6 @@ providers:
     cloud-images:
       - name: ubuntu-bionic
         image-id: ami-07c1207a9d40bc3bd
-      - name: centos-8
-        # https://wiki.centos.org/Cloud/AWS
-        image-id: ami-000e7ce4dd68e7a11
       - name: QRadarCE-7.3.1-RHEL75EUS-20200214.0
         image-id: ami-09477933a629d44bf
       - name: SplunkEnterprise-SES-8.0.0-RHEL77-20191105.0
@@ -106,33 +103,6 @@ providers:
                   sudo: ALL=(ALL) NOPASSWD:ALL
               runcmd:
                 - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
-          - name: centos-8-1vcpu
-            cloud-image: centos-8
-            instance-type: t2.small
-            volume-size: 80
-            key-name: zuul
-            userdata: |
-              #cloud-config
-              package_update: true
-              bootcmd:
-                - dnf install -y epel-release
-              packages:
-                - git
-                - python3-virtualenv
-                - unbound
-              users:
-                - name: zuul
-                  gecos: Zuul user
-                  primary_group: zuul
-                  groups: adm, wheel, systemd-journal
-                  lock_passwd: true
-                  ssh_authorized_keys:
-                    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDI3XA0A84nUpCr9mfkrDjBdoNFtYMXqXMm2+WsGrOJUA2ESodUDDfTKmsA/xEygdCnj8JfSC3SYhc0uKHVe0RdG20mzntUqD50kB0STFeOHh3ee7FXmMxcLqLlyY9pJkn1V5WOi/D1Lbz8MwRUVBfqufryavwHla/9CPuAtPcut8mTUB0+Rapnv8W3n4dA6PqHNW1tylJUXj6P4trJPnFrdfMaIxc21tfd/QrMM4h90phW3zNILE0qF9UHpQxP0zew/LcD9rc+IhnbgC3DeCQDyiqJOsJRDo58RuwWmQHCF0SfiFQJ4qwrc6TFSJqSdi2aRY0S/vRMbXkD+6Hg2KWQyz6Z6EpY7RARletqJwNnzuuhXr2HSCj5QALe+0U/aUEX+dnydYBX6Nqa+0Rz/qV5aUk4YP1C2/dBCAdbYXPotBT6QBfekE428mJV8Mr7G/M7kwZ8v9WjytyJ8/FYNuekYDWonk6QTwDgQhMTiQI3Yxnu3ID63BL959lfUIv96bsifVI6/D36KTAdFi/dl7Omn5MZ9A5JXA7l+yEJKf4pcPTpQcPbjGSKyaPu0uffEjV9CTr3+VMwzq1uenxGDQ9cT/ud4pEEjwU/ihr6yttouTCvDu9ydrflHljUXxf+X00NW7HkrHnvS43AGnxQzi9g2lTOC9yDlDGbQjmnVjec7w== zuul-executor
-                  sudo: ALL=(ALL) NOPASSWD:ALL
-              runcmd:
-                - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
-                - python3 -m pip install --upgrade pip
-                - python3 -m pip install --upgrade tox
           - name: QRadarCE-7.3.1
             cloud-image: QRadarCE-7.3.1-RHEL75EUS-20200214.0
             instance-type: t2.xlarge


### PR DESCRIPTION
Disable centos-8 for now, this until we are able to distinguish properly
the labels that can run nested nodes and the others (EC2).