### PR TITLE
Switch centos-8 ssh host keys to FIPs mode

### DIFF
--- a/nodepool/elements/nodepool-base/finalise.d/89-sshd-keygen
+++ b/nodepool/elements/nodepool-base/finalise.d/89-sshd-keygen
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (C) 2011-2013 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dib-lint: disable=set setu setpipefail indent
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -e
+
+# We want to enable FIPs mode for centos-8, default to a good ssh host key
+# format.
+if [ ${DISTRO_NAME} = "centos" -a ${DIB_RELEASE} -lt 8 ]; then
+    sshd_keygen_path_dib="/etc/systemd/system"
+    nodepool_base="$(dirname $0)/../ssh-keygen.target"
+    cp -RP $nodepool_base /etc/systemd/system/sshd-keygen.target
+fi

--- a/nodepool/elements/nodepool-base/sshd-keygen.target
+++ b/nodepool/elements/nodepool-base/sshd-keygen.target
@@ -1,0 +1,3 @@
+[Unit]
+Wants=sshd-keygen@ecdsa.service
+PartOf=sshd.service


### PR DESCRIPTION
This allows us to switch to FIPs mode for testing, and keeps
zuul-executors happy with right known_hosts.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>