### PR TITLE
Remove auth_type for opendev

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -97,7 +97,6 @@ app_key = {{ zuul_user_home }}/.ssh/github_3pci_id_rsa
 webhook_token = {{ __zuul_conf_connection_github_3pci_webhook_token }}
 
 [connection opendev.org]
-auth_type = digest
 canonical_hostname = opendev.org
 driver = gerrit
 password = {{ __zuul_conf_connection_opendev_password }}


### PR DESCRIPTION
Since opendev upgraded gerrit, we no longer need this setting.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>