### PR TITLE
Allow anonymous access to zuul-registry

### DIFF
--- a/zuul-registry/etc/zuul-registry/registry.yaml.j2
+++ b/zuul-registry/etc/zuul-registry/registry.yaml.j2
@@ -7,6 +7,9 @@ registry:
   secret: '{{ __zuul_registry_yaml_registry_secret }}'
   public-url: 'https://{{ inventory_hostname }}:5000'
   users:
+    - name: anonymous
+      pass: ''
+      access: read
     - name: '{{ __zuul_registry_yaml_registry_user_name }}'
       pass: '{{ __zuul_registry_yaml_registry_user_pass }}'
       access: write


### PR DESCRIPTION
It is helpful to allow users to download images we have build, for local
testing. They should not be used in production however.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>