### PR TITLE
Add ubuntu-bionic-2vcpu support

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -46,6 +46,8 @@ labels:
     max-ready-age: 600
   - name: ubuntu-bionic-1vcpu
     max-ready-age: 600
+  - name: ubuntu-bionic-2vcpu
+    max-ready-age: 600
   - name: ubuntu-bionic-1vcpu-without-nested
     max-ready-age: 600
   - name: ubuntu-bionic-4vcpu
@@ -356,6 +358,10 @@ providers:
             flavor-name: l1.small
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
+          - name: ubuntu-bionic-2vcpu
+            flavor-name: l1.medium
+            diskimage: ubuntu-bionic
+            key-name: infra-root-keys
           - name: ubuntu-bionic-4vcpu
             flavor-name: l1.large
             diskimage: ubuntu-bionic
@@ -490,6 +496,10 @@ providers:
               - Public Internet
           - name: ubuntu-bionic-1vcpu
             flavor-name: s1.small
+            diskimage: ubuntu-bionic
+            key-name: infra-root-keys
+          - name: ubuntu-bionic-2vcpu
+            flavor-name: s1.medium
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
           - name: ubuntu-bionic-4vcpu

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -34,6 +34,8 @@ labels:
     max-ready-age: 600
   - name: ubuntu-bionic-1vcpu
     max-ready-age: 600
+  - name: ubuntu-bionic-2vcpu
+    max-ready-age: 600
   - name: ubuntu-bionic-4vcpu
     max-ready-age: 600
   - name: ubuntu-xenial-1vcpu
@@ -198,6 +200,12 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
+          - name: ubuntu-bionic-2vcpu
+            flavor-name: v2-highcpu-2
+            diskimage: ubuntu-bionic
+            key-name: infra-root-keys
+            boot-from-volume: true
+            volume-size: 80
           - name: ubuntu-bionic-4vcpu
             flavor-name: v2-highcpu-4
             diskimage: ubuntu-bionic
@@ -327,6 +335,12 @@ providers:
             volume-size: 40
           - name: ubuntu-bionic-1vcpu
             flavor-name: v2-highcpu-1
+            diskimage: ubuntu-bionic
+            key-name: infra-root-keys
+            boot-from-volume: true
+            volume-size: 80
+          - name: ubuntu-bionic-2vcpu
+            flavor-name: v2-highcpu-2
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
             boot-from-volume: true


### PR DESCRIPTION
Container builds should be fine using 2vpcu suppot.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>