### PR TITLE
Revert "nodepool: fedora-33 image definition for nodepool"

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -124,23 +124,6 @@ diskimages:
       QEMU_IMG_OPTIONS: compat=0.10
     python-path: /usr/bin/python3
 
-  - name: fedora-33
-    elements:
-      - fedora-minimal
-      - growroot
-      - nodepool-base
-      - openssh-server
-      - simple-init
-      - vm
-    env-vars:
-      DIB_CHECKSUM: '1'
-      DIB_GRUB_TIMEOUT: '0'
-      DIB_INSTALLTYPE_pip_and_virtualenv: 'package'
-      DIB_RELEASE: '33'
-      DIB_SIMPLE_INIT_NETWORKMANAGER: '1'
-      QEMU_IMG_OPTIONS: compat=0.10
-    python-path: /usr/bin/python3
-
   - name: ubuntu-bionic
     pause: true
     elements:


### PR DESCRIPTION
This reverts commit 9a38e0f4d16a35964c4018a50014ded6f1330ae7.

This image isn't building, someone needs to debug why before we try to
bring it online.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>