### PR TITLE
Switch to v3 flavors in vexxhost

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -136,11 +136,9 @@ providers:
             boot-from-volume: true
             volume-size: 80
           - name: centos-7-4vcpu
-            flavor-name: v2-highcpu-4
+            flavor-name: v3-standard-4
             diskimage: centos-7
             key-name: infra-root-keys
-            boot-from-volume: true
-            volume-size: 80
           - name: centos-8-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: centos-8
@@ -201,17 +199,13 @@ providers:
             boot-from-volume: true
             volume-size: 80
           - name: ubuntu-bionic-2vcpu
-            flavor-name: v2-highcpu-2
+            flavor-name: v3-standard-2
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
-            boot-from-volume: true
-            volume-size: 80
           - name: ubuntu-bionic-4vcpu
-            flavor-name: v2-highcpu-4
+            flavor-name: v3-standard-4
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
-            boot-from-volume: true
-            volume-size: 80
           - name: ubuntu-xenial-1vcpu
             flavor-name: v2-highcpu-1
             diskimage: ubuntu-xenial


### PR DESCRIPTION
These are new flavors, that are a little cheaper and don't use boot
volumes.  Lets see how well they work.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>