### PR TITLE
bump the vcenter 7.0.1 image

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -268,7 +268,7 @@ providers:
       - name: VMware-VCSA-all-6.7.0-14836122-20201125
         config-drive: true
         python-path: /usr/bin/python3
-      - name: VMware-VCSA-all-7.0.1-16860138-20210215
+      - name: VMware-VCSA-all-7.0.1-16860138-20210217-3
         config-drive: true
         python-path: /usr/bin/python3
     pools:
@@ -400,7 +400,7 @@ providers:
             key-name: infra-root-keys
           - name: vmware-vcsa-7.0.0
             flavor-name: s1.xlarge
-            cloud-image: VMware-VCSA-all-7.0.1-16860138-20210215
+            cloud-image: VMware-VCSA-all-7.0.1-16860138-20210217-3
             key-name: infra-root-keys
 
   - name: limestone-us-slc
@@ -540,7 +540,7 @@ providers:
             key-name: infra-root-keys
           - name: vmware-vcsa-7.0.0
             flavor-name: s1.xlarge
-            cloud-image: VMware-VCSA-all-7.0.1-16860138-20210215
+            cloud-image: VMware-VCSA-all-7.0.1-16860138-20210217-3
             key-name: infra-root-keys
 
 diskimages:

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -100,7 +100,7 @@ providers:
       - name: VMware-VCSA-all-6.7.0-14836122-20201125
         config-drive: true
         python-path: /usr/bin/python3
-      - name: VMware-VCSA-all-7.0.1-16860138-20210215
+      - name: VMware-VCSA-all-7.0.1-16860138-20210217-3
         config-drive: true
         python-path: /usr/bin/python3
 
@@ -232,7 +232,7 @@ providers:
             volume-size: 40
           - name: vmware-vcsa-7.0.0
             flavor-name: v2-standard-4
-            cloud-image: VMware-VCSA-all-7.0.1-16860138-20210215
+            cloud-image: VMware-VCSA-all-7.0.1-16860138-20210217-3
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 55
@@ -373,7 +373,7 @@ providers:
             volume-size: 40
           - name: vmware-vcsa-7.0.0
             flavor-name: v2-standard-4
-            cloud-image: VMware-VCSA-all-7.0.1-16860138-20210215
+            cloud-image: VMware-VCSA-all-7.0.1-16860138-20210217-3
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 55


### PR DESCRIPTION
This time, the root volume only takes 12GB. The first 7.0.1 images were
at 55GB+.