### PR TITLE
Remove ze04.ca-ymq-1.vexxhost.zuul.ansible.com

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -121,14 +121,6 @@ all:
         public_ipv4: 38.108.68.251
         public_ipv6: 2604:e100:3:0:f816:3eff:fecc:bdea
 
-    ze04.ca-ymq-1.vexxhost.zuul.ansible.com:
-      ansible_host: 199.19.213.57
-      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIDU4C9uqgIwJbpn8bRMDLgTYwE9fiCO5NkDHdoRcGbJ7
-      ansible_user: windmill
-      node_attributes:
-        public_ipv4: 199.19.213.57
-        public_ipv6: 2604:e100:1:0:f816:3eff:fec6:9e90
-
     zm01.sjc1.vexxhost.zuul.ansible.com:
       ansible_host: 38.108.68.49
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAINeofBzQGRkZrmRxHLF62VlAgFsEAX/g81toILZVocZE
@@ -209,7 +201,6 @@ all:
     disabled:
       hosts:
         bastion01.sjc1.vexxhost.zuul.ansible.com:
-        ze04.ca-ymq-1.vexxhost.zuul.ansible.com:
 
     # NOTE(pabelanger): We currently only support a single gear host in this
     # group.  This means, the first host listed will only be used by our
@@ -265,7 +256,6 @@ all:
         ze01.sjc1.vexxhost.zuul.ansible.com:
         ze02.sjc1.vexxhost.zuul.ansible.com:
         ze03.sjc1.vexxhost.zuul.ansible.com:
-        ze04.ca-ymq-1.vexxhost.zuul.ansible.com:
 
     # NOTE(pabelanger): We currently only support a single zuul-fingergw host
     # in this group.  This means, the first host listed will only be used by


### PR DESCRIPTION
Due to network issues and the fact we do not use it, lets remove it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>