### PR TITLE
Properly replace ze04

### DIFF
--- a/ansible/group_vars/bastion.yaml
+++ b/ansible/group_vars/bastion.yaml
@@ -56,6 +56,6 @@ iptables_allowed_hosts:
   - address: ze03.sjc1.vexxhost.zuul.ansible.com
     protocol: tcp
     port: 19885
-  - address: ze04.ca-ymq-1.vexxhost.zuul.ansible.com
+  - address: ze04.us-dfw-1.limestone.zuul.ansible.com
     protocol: tcp
     port: 19885

--- a/ansible/group_vars/gear.yaml
+++ b/ansible/group_vars/gear.yaml
@@ -182,7 +182,7 @@ iptables_allowed_hosts:
     protocol: tcp
     port: 4730
 
-  - address: ze04.ca-ymq-1.vexxhost.zuul.ansible.com
+  - address: ze04.us-dfw-1.limestone.zuul.ansible.com
     protocol: tcp
     port: 4730
 

--- a/ansible/group_vars/statsd.yaml
+++ b/ansible/group_vars/statsd.yaml
@@ -65,7 +65,7 @@ iptables_allowed_hosts:
     protocol: udp
     port: 8125
 
-  - address: ze04.ca-ymq-1.vexxhost.zuul.ansible.com
+  - address: ze04.us-dfw-1.limestone.zuul.ansible.com
     protocol: udp
     port: 8125
 

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -121,6 +121,14 @@ all:
         public_ipv4: 38.108.68.251
         public_ipv6: 2604:e100:3:0:f816:3eff:fecc:bdea
 
+    ze04.us-dfw-1.limestone.zuul.ansible.com:
+      ansible_host: 162.253.42.14
+      ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAIEHa9HMRVv3vT1Euuuv5QhEB6ct4mzHkDEXkWCxozKOY
+      ansible_user: windmill
+      node_attributes:
+        public_ipv4: 162.253.42.14
+        public_ipv6: 2607:ff68:100:a::8f
+
     zm01.sjc1.vexxhost.zuul.ansible.com:
       ansible_host: 38.108.68.49
       ansible_ssh_host_key_ed25519_public: AAAAC3NzaC1lZDI1NTE5AAAAINeofBzQGRkZrmRxHLF62VlAgFsEAX/g81toILZVocZE
@@ -256,6 +264,7 @@ all:
         ze01.sjc1.vexxhost.zuul.ansible.com:
         ze02.sjc1.vexxhost.zuul.ansible.com:
         ze03.sjc1.vexxhost.zuul.ansible.com:
+        ze04.us-dfw-1.limestone.zuul.ansible.com:
 
     # NOTE(pabelanger): We currently only support a single zuul-fingergw host
     # in this group.  This means, the first host listed will only be used by

--- a/doc/source/ansible_zuul.rst
+++ b/doc/source/ansible_zuul.rst
@@ -89,29 +89,29 @@ Ansible Zuul Hosts
 
 .. table:: **Ansible Zuul Hosts**
 
-  =========================================  ========  =================
-  Host                                       Provider  Role
-  =========================================  ========  =================
-  bastion01.sjc1.vexxhost.zuul.ansible.com   vexxhost  Bastion Node
-  borg01.ca-ymq-1.vexxhost.zuul.ansible.com  vexxhost  Borg Backups
-  db01.sjc1.vexxhost.zuul.ansible.com        vexxhost  DiskImage Builder
-  nb01.sjc1.vexxhost.zuul.ansible.com        vexxhost  Nodepool Builder
-  nb02.sjc1.vexxhost.zuul.ansible.com        vexxhost  Nodepool Builder
-  nl01.sjc1.vexxhost.zuul.ansible.com        vexxhost  Nodepool Launcher
-  nl02.sjc1.vexxhost.zuul.ansible.com        vexxhost  Nodepool launcher
-  statsd01.sjc1.vexxhost.zuul.ansible.com    vexxhost  Zuul Executor
-  ze01.sjc1.vexxhost.zuul.ansible.com        vexxhost  Zuul Executor
-  ze02.sjc1.vexxhost.zuul.ansible.com        vexxhost  Zuul Executor
-  ze03.sjc1.vexxhost.zuul.ansible.com        vexxhost  Zuul Executor
-  ze04.ca-ymq-1.vexxhost.zuul.ansible.com    vexxhost  Zuul Executor
-  zk01.sjc1.vexxhost.zuul.ansible.com        vexxhost  ZooKeeper Node
-  zk02.sjc1.vexxhost.zuul.ansible.com        vexxhost  ZooKeeper Node
-  zk03.sjc1.vexxhost.zuul.ansible.com        vexxhost  ZooKeeper Node
-  zm01.sjc1.vexxhost.zuul.ansible.com        vexxhost  Zuul Merger
-  zm02.sjc1.vexxhost.zuul.ansible.com        vexxhost  Zuul Merger
-  zs01.sjc1.vexxhost.zuul.ansible.com        vexxhost  Zuul Scheduler
-  zs02.sjc1.vexxhost.zuul.ansible.com        vexxhost  Zuul Scheduler
-  =========================================  ========  =================
+  =========================================  =========  =================
+  Host                                       Provider   Role
+  =========================================  =========  =================
+  bastion01.sjc1.vexxhost.zuul.ansible.com   vexxhost   Bastion Node
+  borg01.ca-ymq-1.vexxhost.zuul.ansible.com  vexxhost   Borg Backups
+  db01.sjc1.vexxhost.zuul.ansible.com        vexxhost   DiskImage Builder
+  nb01.sjc1.vexxhost.zuul.ansible.com        vexxhost   Nodepool Builder
+  nb02.sjc1.vexxhost.zuul.ansible.com        vexxhost   Nodepool Builder
+  nl01.sjc1.vexxhost.zuul.ansible.com        vexxhost   Nodepool Launcher
+  nl02.sjc1.vexxhost.zuul.ansible.com        vexxhost   Nodepool launcher
+  statsd01.sjc1.vexxhost.zuul.ansible.com    vexxhost   Zuul Executor
+  ze01.sjc1.vexxhost.zuul.ansible.com        vexxhost   Zuul Executor
+  ze02.sjc1.vexxhost.zuul.ansible.com        vexxhost   Zuul Executor
+  ze03.sjc1.vexxhost.zuul.ansible.com        vexxhost   Zuul Executor
+  ze04.us-dfw-1.limestone.zuul.ansible.com   limestone  Zuul Executor
+  zk01.sjc1.vexxhost.zuul.ansible.com        vexxhost   ZooKeeper Node
+  zk02.sjc1.vexxhost.zuul.ansible.com        vexxhost   ZooKeeper Node
+  zk03.sjc1.vexxhost.zuul.ansible.com        vexxhost   ZooKeeper Node
+  zm01.sjc1.vexxhost.zuul.ansible.com        vexxhost   Zuul Merger
+  zm02.sjc1.vexxhost.zuul.ansible.com        vexxhost   Zuul Merger
+  zs01.sjc1.vexxhost.zuul.ansible.com        vexxhost   Zuul Scheduler
+  zs02.sjc1.vexxhost.zuul.ansible.com        vexxhost   Zuul Scheduler
+  =========================================  =========  =================
 
 .. note:: Where is zuul web?
 


### PR DESCRIPTION
The previous commit didn't fully remove ze04 from vexxhost. This change
does that, and recreates the replacement in limestone.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>