### PR TITLE
Bump vexxhost ca-ymq-1 to 40 servers

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -123,7 +123,7 @@ providers:
         networks: &provider_vexxhost_pools_v2_highcpu_1_networks
           - public
           - net1
-        max-servers: 35
+        max-servers: 40
         labels:
           - name: asav9-12-3
             flavor-name: v1-standard-2


### PR DESCRIPTION
We've gotten a quota boost that should allow for 5 more servers.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>