### PR TITLE
Move linux nodes to l1 flavors in limestone

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -554,19 +554,19 @@ providers:
               - Private Network (10.0.0.0/8 only)
               - Private Network (Floating Public)
           - name: centos-7-1vcpu
-            flavor-name: s1.small
+            flavor-name: l1.small
             diskimage: centos-7
             key-name: infra-root-keys
           - name: centos-7-4vcpu
-            flavor-name: s1.large
+            flavor-name: l1.large
             diskimage: centos-7
             key-name: infra-root-keys
           - name: centos-7-8vcpu
-            flavor-name: s1.xlarge
+            flavor-name: l1.xlarge
             diskimage: centos-7
             key-name: infra-root-keys
           - name: centos-8-1vcpu
-            flavor-name: s1.small
+            flavor-name: l1.small
             diskimage: centos-8
             key-name: infra-root-keys
           - name: esxi-6.7.0-with-nested-unstable
@@ -584,7 +584,7 @@ providers:
               hostname: esxi1.test
               fqdn: esxi1.test
           - name: fedora-32-1vcpu
-            flavor-name: s1.small
+            flavor-name: l1.small
             diskimage: fedora-32
             key-name: infra-root-keys
           - name: ios-15.6-2T
@@ -620,19 +620,19 @@ providers:
               - Private Network (10.0.0.0/8 only)
               - Public Internet
           - name: ubuntu-bionic-1vcpu
-            flavor-name: s1.small
+            flavor-name: l1.small
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
           - name: ubuntu-bionic-2vcpu
-            flavor-name: s1.medium
+            flavor-name: l1.medium
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
           - name: ubuntu-bionic-4vcpu
-            flavor-name: s1.large
+            flavor-name: l1.large
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
           - name: ubuntu-xenial-1vcpu
-            flavor-name: s1.small
+            flavor-name: l1.small
             diskimage: ubuntu-xenial
             key-name: infra-root-keys
           - name: vqfx-18.1R3


### PR DESCRIPTION
We now have l1 flavors in us-slc, which gives us a boost in hdd disk IO.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>