### PR TITLE
Re-enable zk01

### DIFF
--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -217,7 +217,6 @@ all:
     disabled:
       hosts:
         bastion01.sjc1.vexxhost.zuul.ansible.com:
-        zk01.sjc1.vexxhost.zuul.ansible.com:
         zk02.sjc1.vexxhost.zuul.ansible.com:
         zk03.sjc1.vexxhost.zuul.ansible.com:
 


### PR DESCRIPTION
This will install zookeeper via tarball.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>