### PR TITLE
Enable TLS support on zookeeper

### DIFF
--- a/ansible/group_vars/zookeeper.yaml
+++ b/ansible/group_vars/zookeeper.yaml
@@ -119,6 +119,14 @@ iptables_allowed_hosts:
     protocol: tcp
     port: 2181
 
+  - address: nb01.sjc1.vexxhost.zuul.ansible.com
+    protocol: tcp
+    port: 2281
+
+  - address: nb02.sjc1.vexxhost.zuul.ansible.com
+    protocol: tcp
+    port: 2281
+
   # nodepool-launcher
   - address: nl01.sjc1.vexxhost.zuul.ansible.com
     protocol: tcp
@@ -127,6 +135,14 @@ iptables_allowed_hosts:
   - address: nl02.sjc1.vexxhost.zuul.ansible.com
     protocol: tcp
     port: 2181
+
+  - address: nl01.sjc1.vexxhost.zuul.ansible.com
+    protocol: tcp
+    port: 2281
+
+  - address: nl02.sjc1.vexxhost.zuul.ansible.com
+    protocol: tcp
+    port: 2281
 
   # zuul-scheduler
   - address: zs01.sjc1.vexxhost.zuul.ansible.com

--- a/zookeeper/etc/zookeeper/conf/zoo.cfg
+++ b/zookeeper/etc/zookeeper/conf/zoo.cfg
@@ -27,28 +27,10 @@ server.{{ loop.index }}={{ hostvars[host].ansible_host | ipwrap }}:2888:3888
 # to a positive integer (1 and above) to enable the auto purging.
 autopurge.purgeInterval=6
 
-# To avoid seeks ZooKeeper allocates space in the transaction log file in
-# blocks of preAllocSize kilobytes. The default block size is 64M. One reason
-# for changing the size of the blocks is to reduce the block size if snapshots
-# are taken more often. (Also, see snapCount).
-#preAllocSize=65536
+# Necessary for TLS support
+serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
 
-# Clients can submit requests faster than ZooKeeper can process them,
-# especially if there are a lot of clients. To prevent ZooKeeper from running
-# out of memory due to queued requests, ZooKeeper will throttle clients so that
-# there is no more than globalOutstandingLimit outstanding requests in the
-# system. The default limit is 1,000.ZooKeeper logs transactions to a
-# transaction log. After snapCount transactions are written to a log file a
-# snapshot is started and a new transaction log file is started. The default
-# snapCount is 10,000.
-#snapCount=1000
-
-# If this option is defined, requests will be will logged to a trace file named
-# traceFile.year.month.day.
-#traceFile=
-
-# Leader accepts client connections. Default value is "yes". The leader machine
-# coordinates updates. For higher update throughput at thes slight expense of
-# read throughput the leader can be configured to not accept clients and focus
-# on coordination.
-#leaderServes=yes
+# Client TLS configuration
+secureClientPort=2281
+ssl.keyStore.location={{ zookeeper_file_ssl_keystore_dest }}
+ssl.trustStore.location={{ zookeeper_file_ssl_truststore_dest }}


### PR DESCRIPTION
This allows clients to start to connect via TLS to zookeeper.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>