### PR TITLE
Remove ansible 2.6 from zuul-executors

### DIFF
--- a/ansible/group_vars/zuul-executor.yaml
+++ b/ansible/group_vars/zuul-executor.yaml
@@ -23,13 +23,6 @@ zuul_service_zuul_executor_state: started
 
 zuul_executor_ansible:
   - ansible_pip_name:
-      - ansible==2.6.20
-      - ara<1.0.0
-      - openstacksdk
-    ansible_pip_virtualenv_python: python3
-    ansible_pip_virtualenv: /opt/venv/zuul-ansible/2.6.20
-    ansible_pip_virtualenv_symlink: /var/lib/zuul/venv/ansible/2.6
-  - ansible_pip_name:
       - ansible==2.7.16
       - ara<1.0.0
       - openstacksdk


### PR DESCRIPTION
We no longer support this version of ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>