### PR TITLE
nodepool/f34: use fedora element

### DIFF
--- a/nodepool/elements/fedora-fork/README.rst
+++ b/nodepool/elements/fedora-fork/README.rst
@@ -1,0 +1,20 @@
+======
+fedora
+======
+
+Use Fedora cloud images as the baseline for built disk images. For further
+details see the redhat-common README.
+
+Environment Variables
+---------------------
+
+DIB_DISTRIBUTION_MIRROR:
+   :Required: No
+   :Default: None
+   :Description: To use a Fedora Yum mirror, set this variable to the mirror URL
+                 before running bin/disk-image-create. This URL should point to
+                 the directory containing the ``releases/updates/development``
+                 and ``extras`` directories.
+   :Example: ``DIB\_DISTRIBUTION\_MIRROR=http://download.fedoraproject.org/pub/fedora/linux``
+
+

--- a/nodepool/elements/fedora-fork/element-deps
+++ b/nodepool/elements/fedora-fork/element-deps
@@ -1,0 +1,6 @@
+cache-url
+dkms
+redhat-common
+rpm-distro
+source-repositories
+yum

--- a/nodepool/elements/fedora-fork/element-provides
+++ b/nodepool/elements/fedora-fork/element-provides
@@ -1,0 +1,1 @@
+operating-system

--- a/nodepool/elements/fedora-fork/environment.d/10-fedora-distro-name.bash
+++ b/nodepool/elements/fedora-fork/environment.d/10-fedora-distro-name.bash
@@ -1,0 +1,33 @@
+export DISTRO_NAME=fedora
+export DIB_RELEASE=${DIB_RELEASE:-34}
+export EFI_BOOT_DIR="EFI/fedora"
+
+# Note the filename URL has a "sub-release" in it
+#  http:// ... Fedora-Cloud-Base-25-1.3.x86_64.qcow2
+#                                   ^^^
+# It's not exactly clear how this is generated, or how we could
+# determine this programatically.  Other projects have more
+# complicated regex-based scripts to find this, which we can examine
+# if this becomes an issue ... see thread at [1]
+#
+# [1] https://lists.fedoraproject.org/archives/list/cloud@lists.fedoraproject.org/thread/2WFO2FKIGUQYRQXIR35UVJGRHF7LQENJ/
+if [ -n "${DIB_FEDORA_SUBRELEASE:-}" ]; then
+    echo "using DIB_FEDORA_SUBRELEASE"
+elif [[ ${DIB_RELEASE} == '28' ]]; then
+    export DIB_FEDORA_SUBRELEASE=1.1
+elif [[ ${DIB_RELEASE} == '29' ]]; then
+    export DIB_FEDORA_SUBRELEASE=1.2
+elif [[ ${DIB_RELEASE} == '30' ]]; then
+    export DIB_FEDORA_SUBRELEASE=1.2
+elif [[ ${DIB_RELEASE} == '31' ]]; then
+    export DIB_FEDORA_SUBRELEASE=1.9
+elif [[ ${DIB_RELEASE} == '32' ]]; then
+    export DIB_FEDORA_SUBRELEASE=1.6
+elif [[ ${DIB_RELEASE} == '33' ]]; then
+    export DIB_FEDORA_SUBRELEASE=1.2
+elif [[ ${DIB_RELEASE} == '34' ]]; then
+    export DIB_FEDORA_SUBRELEASE=1.2
+else
+    echo "Unsupported Fedora release"
+    exit 1
+fi

--- a/nodepool/elements/fedora-fork/environment.d/11-yum-dnf.bash
+++ b/nodepool/elements/fedora-fork/environment.d/11-yum-dnf.bash
@@ -1,0 +1,8 @@
+# since f22, dnf is the yum replacement.  Mostly it drops in
+# unmodified, so while we transition KISS and use this to choose
+
+if [ $DIB_RELEASE -ge 22 ]; then
+    export YUM=dnf
+else
+    export YUM=yum
+fi

--- a/nodepool/elements/fedora-fork/package-installs.yaml
+++ b/nodepool/elements/fedora-fork/package-installs.yaml
@@ -1,0 +1,34 @@
+# On a fresh Fedora 18 install you might have to update audit in order to
+# fix a conflict with a file from the glibc package.
+# https://bugzilla.redhat.com/show_bug.cgi?id=894307
+audit:
+
+# The version of openssl shipped in the fedora cloud image is no longer
+# compatible with new python environments installed by virtualenv, so we need
+# to update it first.
+# See https://bugs.launchpad.net/diskimage-builder/+bug/1254879
+openssl:
+
+# FIXME: To avoid conflict between the pyOpenSSL installed via python-pip
+# and pyOpenSSL installed via yum, we are going to sort it out installing
+# it earlier at the beginning of the image building process. Python-pip
+# is installing pyOpenSSL as part of satisfying the requirements.txt
+# in python-glanceclient and afterwards yum tries to install it as a
+# dependency of the python-paste package needed for the heat element,
+# this seems to be conflicting and causing the image building process to
+# fail. The problem is happening on a Fedora 18 system.
+pyOpenSSL:
+
+# Workaround for:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1066983
+vim-minimal:
+
+# kernel modules to match the core kernel
+# Newer Fedora 21 splits these out into a separate package.
+# It contains iscsi_tcp.ko (for Ironic) among other things like network
+# driver modules, etc.
+kernel-modules:
+
+# This small package is required on Fedora 21 in order to build some
+# packages via source (MySQL driver).
+redhat-rpm-config:

--- a/nodepool/elements/fedora-fork/pre-install.d/00-02-set-fedora-mirror
+++ b/nodepool/elements/fedora-fork/pre-install.d/00-02-set-fedora-mirror
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+DIB_DISTRIBUTION_MIRROR=${DIB_DISTRIBUTION_MIRROR:-}
+
+[ -n "$DIB_DISTRIBUTION_MIRROR" ] || exit 0
+
+if [[ ${DIB_RELEASE} -gt 27 ]]; then
+    # urgh, the repo is wrong in the "baseurl" line, see
+    #  https://pagure.io/fedora/repos/issue/70
+    for FILE in /etc/yum.repos.d/fedora-updates.repo /etc/yum.repos.d/fedora-updates-testing.repo; do
+        sed -i "s,/os/,," $FILE
+    done
+fi
+
+for FILE in /etc/yum.repos.d/fedora.repo /etc/yum.repos.d/fedora-updates.repo /etc/yum.repos.d/fedora-updates-testing.repo; do
+    # In >=32 this became "download.example" not
+    # "download.fedoraproject.org"
+    cat $FILE
+    sudo sed -e "s,^#baseurl=http[s]*://download.\(fedoraproject.org\|example\)/pub/fedora/linux,baseurl=$DIB_DISTRIBUTION_MIRROR,;/^metalink/d" -i $FILE
+    cat $FILE
+done

--- a/nodepool/elements/fedora-fork/pre-install.d/02-set-machine-id
+++ b/nodepool/elements/fedora-fork/pre-install.d/02-set-machine-id
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+# The systemd .spec file does this in %post [1] and it turns out that
+# (in what is possibly a bug [2]) that kernel install requires
+# /etc/machine-id.  This affects "fedora" (the image-based build) if
+# there is no systemd update to install ... with "fedora-minimal" we
+# are always installing into the chroot so, so %post always runs and
+# this is always run
+#
+# [1] https://src.fedoraproject.org/rpms/systemd/blob/master/f/systemd.spec
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=1486124
+
+systemd-machine-id-setup

--- a/nodepool/elements/fedora-fork/root.d/10-fedora-cloud-image
+++ b/nodepool/elements/fedora-fork/root.d/10-fedora-cloud-image
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+[ -n "$ARCH" ]
+[ -n "$TARGET_ROOT" ]
+
+if [ 'amd64' = "$ARCH" ] ; then
+    ARCH="x86_64"
+fi
+
+DIB_LOCAL_IMAGE=${DIB_LOCAL_IMAGE:-""}
+
+if [ -n "$DIB_LOCAL_IMAGE" ]; then
+    IMAGE_LOCATION=$DIB_LOCAL_IMAGE
+    # No need to copy a local image into the cache directory, so just specify
+    # the cached path as the original path.
+    CACHED_IMAGE=$IMAGE_LOCATION
+    BASE_IMAGE_FILE=`basename $DIB_LOCAL_IMAGE`
+    BASE_IMAGE_TAR=$BASE_IMAGE_FILE.tgz
+else
+    # note default DIB_RELEASE set in environment setup
+    case ${ARCH} in
+    x86_64|aarch64)
+        if [[ ${DIB_RELEASE} -ge 28 ]]; then
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-https://download.fedoraproject.org/pub/fedora/linux/releases/${DIB_RELEASE}/Cloud/${ARCH}/images}
+        else
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-https://download.fedoraproject.org/pub/fedora/linux/releases/${DIB_RELEASE}/CloudImages/${ARCH}/images}
+        fi
+        ;;
+    ppc64|ppc64le)
+        if [[ ${DIB_RELEASE} -ge 28 ]]; then
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-https://dl.fedoraproject.org/pub/fedora-secondary/releases/${DIB_RELEASE}/Cloud/${ARCH}/images}
+        else
+            DIB_CLOUD_IMAGES=${DIB_CLOUD_IMAGES:-https://dl.fedoraproject.org/pub/fedora-secondary/releases/${DIB_RELEASE}/CloudImages/${ARCH}/images}
+        fi
+        ;;
+    *)
+        echo "Error: unknown ARCH: ${ARCH}"
+        exit 1
+        ;;
+    esac
+    BASE_IMAGE_FILE=${BASE_IMAGE_FILE:-Fedora-Cloud-Base-$DIB_RELEASE-$DIB_FEDORA_SUBRELEASE.$ARCH.qcow2}
+    BASE_IMAGE_TAR=Fedora-Cloud-Base-$DIB_RELEASE-$DIB_FEDORA_SUBRELEASE.$ARCH.tgz
+    IMAGE_LOCATION=$DIB_CLOUD_IMAGES/$BASE_IMAGE_FILE
+    CACHED_IMAGE=$DIB_IMAGE_CACHE/$BASE_IMAGE_FILE
+fi
+
+$TMP_HOOKS_PATH/bin/extract-image $BASE_IMAGE_FILE $BASE_IMAGE_TAR $IMAGE_LOCATION $CACHED_IMAGE

--- a/nodepool/elements/fedora-fork/test-elements/build-succeeds/element-deps
+++ b/nodepool/elements/fedora-fork/test-elements/build-succeeds/element-deps
@@ -1,0 +1,2 @@
+base
+openstack-ci-mirrors

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -128,7 +128,7 @@ diskimages:
 
   - name: fedora-34
     elements:
-      - fedora-minimal
+      - fedora-fork
       - growroot
       - nodepool-base
       - openssh-server


### PR DESCRIPTION
The fedora-minimal depends on the yumdownloader command from yum-utils.
The version from Ubuntu 18.04 seems to be too old and not able to
properly resolve the dependency. We always end up with the following
error:
Error: openssl1.1 conflicts with 1:openssl-libs-1.1.1k-1.fc34.x86_64

By using the fedora element instead, we use the official Fedora cloud
image as base image.

We also need this:

https://review.opendev.org/c/openstack/diskimage-builder/+/799339