### PR TITLE
fedora: use fedora-container as root image

### DIFF
--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -128,7 +128,7 @@ diskimages:
 
   - name: fedora-34
     elements:
-      - fedora-minimal
+      - fedora-container
       - growroot
       - nodepool-base
       - openssh-server


### PR DESCRIPTION
As discussed here: https://github.com/ansible-network/windmill-config/pull/853