### PR TITLE
bump VCSA image

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -409,7 +409,7 @@ providers:
       - name: esxi-6.7.0-20190802001-STANDARD-20210719
         config-drive: true
         python-path: /usr/bin/python3
-      - name: VMware-VCSA-all-7.0.2-17694817-20210526
+      - name: VMware-VCSA-all-7.0.2-17694817-20210726
         config-drive: true
         python-path: /usr/bin/python3
     pools:
@@ -542,7 +542,7 @@ providers:
               - Private Network (Floating Public)
           - name: vmware-vcsa-7.0.2
             flavor-name: s1.xlarge
-            cloud-image: VMware-VCSA-all-7.0.2-17694817-20210526
+            cloud-image: VMware-VCSA-all-7.0.2-17694817-20210726
             key-name: infra-root-keys
   - name: limestone-us-slc
     cloud: limestone
@@ -682,7 +682,7 @@ providers:
               - Private Network (Floating Public)
           - name: vmware-vcsa-7.0.2
             flavor-name: s1.xlarge
-            cloud-image: VMware-VCSA-all-7.0.2-17694817-20210526
+            cloud-image: VMware-VCSA-all-7.0.2-17694817-20210726
             key-name: infra-root-keys
 diskimages:
   - name: centos-7

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -112,7 +112,7 @@ providers:
       - name: esxi-7.0.2-17630552-STANDARD-20210430
         config-drive: true
         python-path: /usr/bin/python3
-      - name: VMware-VCSA-all-7.0.2-17694817-20210526
+      - name: VMware-VCSA-all-7.0.2-17694817-20210726
         config-drive: true
         python-path: /usr/bin/python3
     pools:
@@ -258,7 +258,7 @@ providers:
               - net2
           - name: vmware-vcsa-7.0.2
             flavor-name: v2-standard-4
-            cloud-image: VMware-VCSA-all-7.0.2-17694817-20210526
+            cloud-image: VMware-VCSA-all-7.0.2-17694817-20210726
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 55
@@ -415,7 +415,7 @@ providers:
               - net2
           - name: vmware-vcsa-7.0.2
             flavor-name: v2-standard-4
-            cloud-image: VMware-VCSA-all-7.0.2-17694817-20210526
+            cloud-image: VMware-VCSA-all-7.0.2-17694817-20210726
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 55


### PR DESCRIPTION
Bump to VMware-VCSA-all-7.0.2-17694817-20210726.

Closes: https://github.com/ansible-collections/community.vmware/issues/979