### PR TITLE
Cache repos based off ansible/project-config

### DIFF
--- a/nodepool/elements/cache-files/extra-data.d/50-create-repo-list
+++ b/nodepool/elements/cache-files/extra-data.d/50-create-repo-list
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2011-2013 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import yaml
+
+try:
+    from six.moves.urllib.request import urlopen
+except ImportError:
+    from urllib.request import urlopen
+try:
+    from six.moves.urllib.error import URLError
+except ImportError:
+    from urllib.request import URLError
+
+URL = ('https://raw.githubusercontent.com/ansible/project-config/'
+        'master/github/projects.yaml')
+
+TMP_HOOKS_PATH = os.environ['TMP_HOOKS_PATH']
+PROJECTS_REPOS = os.path.join(TMP_HOOKS_PATH,
+                              'source-repository-projects-yaml')
+GIT_BASE = os.environ.get('GIT_BASE', 'https://github.com')
+
+CUSTOM_PROJECTS_LIST_URL = os.environ.get('DIB_CUSTOM_PROJECTS_LIST_URL')
+
+
+def get_project_list(url):
+    try:
+        projects = []
+        for f in yaml.load(urlopen(url)):
+            # Skip repos that are inactive
+            project = f['project']
+            dirname = os.path.dirname(project)
+            if 'attic' in dirname or dirname == 'stackforge':
+                continue
+            acl = f.get('acl-config')
+            # Ignore retired repositories
+            if acl and os.path.basename(acl) == 'retired.config':
+                continue
+            projects.append(project)
+
+        return projects
+    except URLError:
+        print("Could not open project list url: '%s'" % url)
+        raise
+
+
+def main():
+    projects = []
+    if CUSTOM_PROJECTS_LIST_URL:
+        projects = get_project_list(CUSTOM_PROJECTS_LIST_URL)
+
+    if not projects:
+        projects = get_project_list(URL)
+
+    with open(PROJECTS_REPOS, 'w') as projects_list:
+        for project in projects:
+            args = dict(
+                name=os.path.basename(project),
+                location=os.path.join('/opt/git/github.com', project),
+                url='%s/%s.git' % (GIT_BASE, project),
+                ref='*')
+
+            projects_list.write("%(name)s git %(location)s "
+                                "%(url)s %(ref)s\n" % args)
+
+
+if __name__ == '__main__':
+    main()

--- a/nodepool/elements/cache-files/source-repository-projects
+++ b/nodepool/elements/cache-files/source-repository-projects
@@ -1,1 +1,0 @@
-ansible git /opt/git/github.com/ansible/ansible https://github.com/ansible/ansible.git *


### PR DESCRIPTION
We'll now read our github/projects.yaml file to properly cache repos.
This should mean faster clone times for jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>