### PR TITLE
Temporarily remove eos from limestone

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -30,7 +30,7 @@ labels:
     max-ready-age: 600
   - name: centos-8-stream
     max-ready-age: 600
-  - name: eos-4.24.6
+  - name: eos-4.24.6_remove
     max-ready-age: 600
   - name: esxi-6.7.0
     max-ready-age: 600

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -12,7 +12,7 @@ max-hold-age: 86400
 labels:
   - name: asav9-12-3
     max-ready-age: 600
-  - name: eos-4.24.6_remove
+  - name: eos-4.24.6
     max-ready-age: 600
   - name: centos-7-1vcpu
     max-ready-age: 600


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

To debug the failure in network-ee jobs (https://github.com/ansible-collections/arista.eos/pull/267/checks?check_run_id=3807467410) , removing eos label from limestone.