### PR TITLE
opendev: use IPv4 and a static IP for now

### DIFF
--- a/zuul/zuul.conf.j2
+++ b/zuul/zuul.conf.j2
@@ -106,6 +106,9 @@ webhook_token = {{ __zuul_conf_connection_github_3pci_webhook_token }}
 canonical_hostname = opendev.org
 driver = gerrit
 password = {{ __zuul_conf_connection_opendev_password }}
-server = review.opendev.org
+# ensure we use IPv4 to reach this host until the IPv6 routing problem is resolved.
+# See: https://secure.vexxhost.com/billing/viewticket.php?tid=VYJ-277323&c=KYYHhrX4
+# server = review.opendev.org
+server = 199.204.45.33
 sshkey = {{ zuul_user_home }}/.ssh/gerrit_id_rsa
 user = ansible-zuul


### PR DESCRIPTION
We cannot reach review.opendev.org over IPv6 because of a routing
problem. We've got a ticket opened at Vexxhost.

See: https://secure.vexxhost.com/billing/viewticket.php?tid=VYJ-277323&c=KYYHhrX4
