### PR TITLE
add centos-8-stream-small label

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -28,6 +28,8 @@ labels:
     max-ready-age: 600
   - name: centos-8-1vcpu
     max-ready-age: 600
+  - name: centos-8-stream-small
+    max-ready-age: 600
   - name: centos-8-stream
     max-ready-age: 600
   - name: eos-4.24.6_remove
@@ -448,9 +450,13 @@ providers:
             flavor-name: l1.xlarge
             diskimage: centos-7
             key-name: infra-root-keys
-          - name: centos-8-1vcpu
+          - name: centos-8-1vcpu  # use centos-8-stream-small instead
             flavor-name: l1.small
             diskimage: centos-8
+            key-name: infra-root-keys
+          - name: centos-8-stream-small
+            flavor-name: l1.small
+            diskimage: centos-8-stream
             key-name: infra-root-keys
           - name: centos-8-stream
             flavor-name: l1.large
@@ -586,9 +592,13 @@ providers:
             flavor-name: l1.xlarge
             diskimage: centos-7
             key-name: infra-root-keys
-          - name: centos-8-1vcpu
+          - name: centos-8-1vcpu  # use centos-8-stream-small instead
             flavor-name: l1.small
             diskimage: centos-8
+            key-name: infra-root-keys
+          - name: centos-8-stream-small
+            flavor-name: l1.small
+            diskimage: centos-8-stream
             key-name: infra-root-keys
           - name: centos-8-stream
             flavor-name: l1.large

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -20,6 +20,8 @@ labels:
     max-ready-age: 600
   - name: centos-8-1vcpu
     max-ready-age: 600
+  - name: centos-8-stream-small
+    max-ready-age: 600
   - name: centos-8-stream
     max-ready-age: 600
   - name: esxi-6.7.0
@@ -148,12 +150,16 @@ providers:
             flavor-name: v1-standard-4
             diskimage: centos-7
             key-name: infra-root-keys
-          - name: centos-8-1vcpu
+          - name: centos-8-1vcpu  # use centos-8-stream-small instead
             flavor-name: v2-highcpu-1
             diskimage: centos-8
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
+          - name: centos-8-stream-small
+            flavor-name: v2-highcpu-1
+            diskimage: centos-8-stream
+            key-name: infra-root-keys
           - name: centos-8-stream
             flavor-name: v3-standard-4
             diskimage: centos-8-stream
@@ -300,9 +306,15 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
-          - name: centos-8-1vcpu
+          - name: centos-8-1vcpu  # use centos-8-stream-small instead
             flavor-name: v2-highcpu-1
             diskimage: centos-8
+            key-name: infra-root-keys
+            boot-from-volume: true
+            volume-size: 80
+          - name: centos-8-stream-small
+            flavor-name: v2-highcpu-1
+            diskimage: centos-8-stream
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80


### PR DESCRIPTION
The goal is to deprecate the centos-8-1vcpu which is still based on the
centos-8 image.
