### PR TITLE
vexxhost: v2-highcpu-1 needs boot-from-volume true

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -156,8 +156,8 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
-          - name: centos-8-stream-small
-            flavor-name: v2-highcpu-1
+          - name: centos-8-stream-small  # this flavor comes with __only__ 40GB of disk
+            flavor-name: v3-standard-2
             diskimage: centos-8-stream
             key-name: infra-root-keys
           - name: centos-8-stream
@@ -312,8 +312,8 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
-          - name: centos-8-stream-small
-            flavor-name: v2-highcpu-1
+          - name: centos-8-stream-small  # this flavor comes with __only__ 40GB of disk
+            flavor-name: v3-standard-2
             diskimage: centos-8-stream
             key-name: infra-root-keys
             boot-from-volume: true


### PR DESCRIPTION
The centos-8-stream-small flavor does not start and returns:
`Only volume-backed servers are allowed for flavors with zero disk.`.
