### PR TITLE
v1-standard  flavloirs are not available on sjc1

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -127,14 +127,14 @@ providers:
         max-servers: 40
         labels:
           - name: asav9-12-3
-            flavor-name: v1-standard-2
+            flavor-name: v2-highcpu-1
             cloud-image: asav9-12-3-20200302
             networks:
               - public
               - net1
               - net2
           - name: eos-4.24.6
-            flavor-name: v1-standard-2
+            flavor-name: v2-highcpu-1
             cloud-image: vEOS-4.24.6F-20210712
             networks:
               - public
@@ -147,7 +147,7 @@ providers:
             boot-from-volume: true
             volume-size: 80
           - name: centos-7-4vcpu
-            flavor-name: v1-standard-4
+            flavor-name: v2-highcpu-4
             diskimage: centos-7
             key-name: infra-root-keys
           - name: centos-8-1vcpu  # use centos-8-stream-small instead
@@ -198,7 +198,7 @@ providers:
               - net1
               - net2
           - name: iosxrv-6.1.3
-            flavor-name: v1-standard-4
+            flavor-name: v2-highcpu-4
             cloud-image: iosxrv-6.1.3-20190604
             host-key-checking: false
             networks:
@@ -206,7 +206,7 @@ providers:
               - net2
               - public
           - name: iosxrv-7.0.2
-            flavor-name: v1-standard-8
+            flavor-name: v2-highcpu-8
             cloud-image: iosxrv-7.0.2-20211703
             host-key-checking: false
             networks:
@@ -232,7 +232,7 @@ providers:
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
           - name: ubuntu-bionic-4vcpu
-            flavor-name: v1-standard-4
+            flavor-name: v2-highcpu-4
             diskimage: ubuntu-bionic
             key-name: infra-root-keys
           - name: ubuntu-xenial-1vcpu
@@ -281,14 +281,14 @@ providers:
         max-servers: 35
         labels:
           - name: asav9-12-3
-            flavor-name: v1-standard-2
+            flavor-name: v2-highcpu-1
             cloud-image: asav9-12-3-20200302
             networks:
               - public
               - net1
               - net2
           - name: eos-4.24.6
-            flavor-name: v1-standard-2
+            flavor-name: v2-highcpu-1
             cloud-image: vEOS-4.24.6F-20210712
             networks:
               - public


### PR DESCRIPTION
e.g: `Exception: Unable to find flavor: v1-standard-2`
