### PR TITLE
aws/f34: use t3 instance type

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -137,7 +137,7 @@ providers:
                 - python3 -m pip install --upgrade tox
           - name: fedora-34-1vcpu
             cloud-image: fedora-34
-            instance-type: t2.small
+            instance-type: t3.small
             volume-size: 80
             key-name: zuul
             userdata: |


### PR DESCRIPTION
Depends-On: https://github.com/ansible-network/windmill-config/pull/906

This to benefit from the nvme root disk. Ultimately, we should move all our
nodes to t3.
