### PR TITLE
fedora-35: we need the pip package

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -187,6 +187,7 @@ providers:
                 - git
                 - python3-virtualenv
                 - unbound
+                - pip
               users:
                 - name: op
                   gecos: Zuul operator
@@ -530,6 +531,7 @@ providers:
                 - git
                 - python3-virtualenv
                 - unbound
+                - pip
               users:
                 - name: op
                   gecos: Zuul operator
@@ -710,6 +712,7 @@ providers:
                 - git
                 - python3-virtualenv
                 - unbound
+                - pip
               users:
                 - name: op
                   gecos: Zuul operator

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -238,6 +238,7 @@ providers:
                 - git
                 - python3-virtualenv
                 - unbound
+                - pip
               users:
                 - name: op
                   gecos: Zuul operator
@@ -423,6 +424,7 @@ providers:
                 - git
                 - python3-virtualenv
                 - unbound
+                - pip
               users:
                 - name: op
                   gecos: Zuul operator


### PR DESCRIPTION
We need pip from the system to be able to upgrade pip from pypi, and install tox.
