### PR TITLE
define the ansible-fedora-35-1vcpu alias

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -44,6 +44,8 @@ labels:
     max-ready-age: 600
   - name: fedora-35-1vcpu
     max-ready-age: 600
+  - name: ansible-fedora-35-1vcpu
+    max-ready-age: 600
   - name: ios-15.6-2T
     max-ready-age: 600
   - name: iosxrv-6.1.3
@@ -175,7 +177,8 @@ providers:
                 - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
                 - python3 -m pip install --upgrade pip
                 - python3 -m pip install --upgrade tox
-          - name: fedora-35-1vcpu
+          - &fedora-35-1vcpu-aws
+            name: fedora-35-1vcpu
             cloud-image: fedora-35
             instance-type: t3.small
             volume-size: 80
@@ -209,7 +212,8 @@ providers:
                 - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
                 - python3 -m pip install --upgrade pip
                 - python3 -m pip install --upgrade tox
-
+          - <<: *fedora-35-1vcpu-aws
+            name: ansible-fedora-35-1vcpu
           - name: ubuntu-bionic-1vcpu
             cloud-image: ubuntu-bionic
             instance-type: t2.small
@@ -520,7 +524,8 @@ providers:
             flavor-name: l1.small
             diskimage: fedora-34
             key-name: infra-root-keys
-          - name: fedora-35-1vcpu
+          - &fedora-35-1vcpu-limestone-us-dfw-1
+            name: fedora-35-1vcpu
             flavor-name: s1.small
             cloud-image: Fedora-Cloud-Base-35-1.2.x86_64-20211108
             key-name: infra-root-keys
@@ -553,6 +558,8 @@ providers:
                 - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
                 - python3 -m pip install --upgrade pip
                 - python3 -m pip install --upgrade tox
+          - <<: *fedora-35-1vcpu-limestone-us-dfw-1
+            name: ansible-fedora-35-1vcpu
 
           - name: ios-15.6-2T
             flavor-name: l1.small
@@ -701,7 +708,8 @@ providers:
             flavor-name: l1.small
             diskimage: fedora-34
             key-name: infra-root-keys
-          - name: fedora-35-1vcpu
+          - &fedora-35-1vcpu-limestone-us-slc
+            name: fedora-35-1vcpu
             flavor-name: s1.small
             cloud-image: Fedora-Cloud-Base-35-1.2.x86_64-20211108
             key-name: infra-root-keys
@@ -734,6 +742,9 @@ providers:
                 - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
                 - python3 -m pip install --upgrade pip
                 - python3 -m pip install --upgrade tox
+
+          - <<: *fedora-35-1vcpu-limestone-us-slc
+            name: ansible-fedora-35-1vcpu
           - name: ios-15.6-2T
             flavor-name: s1.small
             cloud-image: ios-15.6-2T-20190524

--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -38,6 +38,8 @@ labels:
     max-ready-age: 600
   - name: fedora-35-1vcpu
     max-ready-age: 600
+  - name: ansible-fedora-35-1vcpu
+    max-ready-age: 600
   - name: ios-15.6-2T
     max-ready-age: 600
   - name: iosxrv-6.1.3
@@ -225,7 +227,8 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
-          - name: fedora-35-1vcpu
+          - &fedora-35-1vcpu-vexxhost-ca-ymq-1
+            name: fedora-35-1vcpu
             flavor-name: v2-highcpu-2-iops
             cloud-image: Fedora-Cloud-Base-35-1.2.x86_64-20211108
             key-name: infra-root-keys
@@ -260,6 +263,8 @@ providers:
                 - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
                 - python3 -m pip install --upgrade pip
                 - python3 -m pip install --upgrade tox
+          - <<: *fedora-35-1vcpu-vexxhost-ca-ymq-1
+            name: ansible-fedora-35-1vcpu
 
           - name: ios-15.6-2T
             flavor-name: v3-standard-2
@@ -411,7 +416,8 @@ providers:
             key-name: infra-root-keys
             boot-from-volume: true
             volume-size: 80
-          - name: fedora-35-1vcpu
+          - &fedora-35-1vcpu-vexxhost-sjc1
+            name: fedora-35-1vcpu
             flavor-name: v2-highcpu-1
             cloud-image: Fedora-Cloud-Base-35-1.2.x86_64-20211108
             key-name: infra-root-keys
@@ -446,6 +452,8 @@ providers:
                 - mv /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/zuul
                 - python3 -m pip install --upgrade pip
                 - python3 -m pip install --upgrade tox
+          - <<: *fedora-35-1vcpu-vexxhost-sjc1
+            name: ansible-fedora-35-1vcpu
 
           - name: ios-15.6-2T
             flavor-name: v2-highcpu-1


### PR DESCRIPTION
This is an transitional alias for fedora-35-1vcpu. It matches the
label from the SoftwareFactory configuration. This allow use
to run the same jobs with both platforms.
