### PR TITLE
vmware: bump the VCSA instance to 32GB

### DIFF
--- a/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl02.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -348,7 +348,7 @@ providers:
             volume-size: 55
           - &vmware-vcsa-7-0-3-vexxhost-ca-ymq-1
             name: vmware-vcsa-7.0.3
-            flavor-name: v2-standard-4-iops
+            flavor-name: v3-standard-8
             cloud-image: VMware-VCSA-all-7.0.3-18778458-20211202
             key-name: infra-root-keys
           - <<: *vmware-vcsa-7-0-3-vexxhost-ca-ymq-1


### PR DESCRIPTION
vSphere 7.0.3 requires more resources and it looks lile he hit the
ceiling a bit too often with just 16GB.
