### PR TITLE
scale down the us-dfw-1 region

### DIFF
--- a/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
+++ b/nodepool/nl01.sjc1.vexxhost.zuul.ansible.com.yaml
@@ -483,7 +483,7 @@ providers:
       # is a real world financial cost in doing so that is charged to the
       # Ansible org.
       - name: s1.small
-        max-servers: 110
+        max-servers: 3
         networks:
           - Public Internet
           - Private Network (10.0.0.0/8 only)


### PR DESCRIPTION
Limestone us-dfw-1 is facing some problem. We've had 506 instance
creation rejected during the last 12h.
